### PR TITLE
WIP: investigating inconsistent tests

### DIFF
--- a/modules/server/src/test/scala/fs2/RPCTests.scala
+++ b/modules/server/src/test/scala/fs2/RPCTests.scala
@@ -105,8 +105,8 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
     "be able to run client bidirectional streaming services" in {
 
-      ignoreOnTravis(
-        "TODO: restore once https://github.com/frees-io/freestyle-rpc/issues/164 is fixed")
+      // ignoreOnTravis(
+      //   "TODO: restore once https://github.com/frees-io/freestyle-rpc/issues/164 is fixed")
 
       freesRPCServiceClient
         .biStreaming(Stream.fromIterator[ConcurrentMonad, E](eList.iterator))
@@ -130,8 +130,8 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
     "be able to run multiple rpc services" in {
 
-      ignoreOnTravis(
-        "TODO: restore once https://github.com/frees-io/freestyle-rpc/issues/164 is fixed")
+      // ignoreOnTravis(
+      //   "TODO: restore once https://github.com/frees-io/freestyle-rpc/issues/164 is fixed")
 
       val tuple =
         (
@@ -189,8 +189,8 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
     "be able to run client bidirectional streaming services" in {
 
-      ignoreOnTravis(
-        "TODO: restore once https://github.com/frees-io/freestyle-rpc/issues/164 is fixed")
+      // ignoreOnTravis(
+      //   "TODO: restore once https://github.com/frees-io/freestyle-rpc/issues/164 is fixed")
 
       freesRPCServiceClient
         .biStreamingCompressed(Stream.fromIterator[ConcurrentMonad, E](eList.iterator))
@@ -214,8 +214,8 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
     "be able to run multiple rpc services" in {
 
-      ignoreOnTravis(
-        "TODO: restore once https://github.com/frees-io/freestyle-rpc/issues/164 is fixed")
+      // ignoreOnTravis(
+      //   "TODO: restore once https://github.com/frees-io/freestyle-rpc/issues/164 is fixed")
 
       val tuple =
         (

--- a/modules/server/src/test/scala/fs2/Utils.scala
+++ b/modules/server/src/test/scala/fs2/Utils.scala
@@ -128,10 +128,7 @@ object Utils extends CommonUtils {
         def clientStreamingCompressed(oa: Stream[F, A]): F[D] = clientStreaming(oa)
 
         def biStreaming(oe: Stream[F, E]): Stream[F, E] =
-          oe.flatMap { e: E =>
-            save(e)
-            Stream.fromIterator(eList.iterator)
-          }
+          Stream.fromIterator(eList.iterator)
 
         def biStreamingWithSchema(oe: Stream[F, E]): Stream[F, E] = biStreaming(oe)
 


### PR DESCRIPTION
# WIP: do not merge

Hey, after testing locally a bit, I've seen that what makes the test fail is that the parameter received in [`biStreaming`](https://github.com/frees-io/freestyle-rpc/blob/master/modules/server/src/test/scala/fs2/Utils.scala#L130-L134) method comes empty some times, and that makes the flatmap fail fast and return the empty stream (which later is materialized to an empty list on the client.)

I'll be conducting some tests in this branch, and updating the description of the PR with my findings, but seems that avoiding that flatmap make most test pass.

---

Currently I'm facing two different errors:

## 1. GRPC error

this one I've been able to replicate it by just executing the tests with a `sbt server/tests` (maybe a couple of times, in travis seems to occur more likely).

`INTERNAL: Failed to frame message`

There are apparently other occurences of that error in the internets:

https://github.com/grpc/grpc-java/issues/1629
https://github.com/bazelbuild/bazel/issues/2822

This one seems to be related with the size of the frame

## 2. Netty error

this one can be replicated with:

```
➜  freestyle-rpc git:(ppg-164-inconsitent-tests) ✗ cat test
import freestyle.rpc.fs2
import freestyle.rpc.common._
import freestyle.rpc.server._
import _root_.fs2.Stream
import freestyle.rpc.server.implicits._
import org.scalatest._
import freestyle.rpc.fs2.Utils._
import freestyle.rpc.fs2.Utils.database._
import freestyle.rpc.fs2.Utils.implicits._

import cats.effect._
import cats.implicits._
import Function.{const => κ}

def biStream=          freesRPCServiceClient.biStreamingCompressed(Stream.fromIterator[ConcurrentMonad, E](eList.iterator))

➜  freestyle-rpc git:(ppg-164-inconsitent-tests) ✗ sbt server/test:console

scala> :load test
scala> serverStart[ConcurrentMonad].unsafeRunSync
scala> (1 to 100) foreach { _ => println(biStream.compile.toList.unsafeRunSync.distinct) }  // repeating this last command a couple of times makes the netty error appear
```

The actual error is:

```
May 31, 2018 9:13:33 AM io.grpc.netty.NettyServerHandler onStreamError
WARNING: Stream Error
io.netty.handler.codec.http2.Http2Exception$StreamException: Received DATA frame for an unknown stream 201
        at io.netty.handler.codec.http2.Http2Exception.streamError(Http2Exception.java:129)
        at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.shouldIgnoreHeadersOrDataFrame(DefaultHttp2ConnectionDecoder.java:535)
        at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onDataRead(DefaultHttp2ConnectionDecoder.java:187)
        at io.netty.handler.codec.http2.Http2InboundFrameLogger$1.onDataRead(Http2InboundFrameLogger.java:48)
        at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readDataFrame(DefaultHttp2FrameReader.java:421)
        at io.netty.handler.codec.http2.DefaultHttp2FrameReader.processPayloadState(DefaultHttp2FrameReader.java:251)
        at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readFrame(DefaultHttp2FrameReader.java:160)
        at io.netty.handler.codec.http2.Http2InboundFrameLogger.readFrame(Http2InboundFrameLogger.java:41)
        at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder.decodeFrame(DefaultHttp2ConnectionDecoder.java:118)
        at io.netty.handler.codec.http2.Http2ConnectionHandler$FrameDecoder.decode(Http2ConnectionHandler.java:390)
        at io.netty.handler.codec.http2.Http2ConnectionHandler.decode(Http2ConnectionHandler.java:450)
        at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:489)
        at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:428)
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:265)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1414)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:945)
        at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:146)
        at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:645)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:580)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:497)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:459)
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:886)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.lang.Thread.run(Thread.java:748)
```

this appears to be happening to other people too:

https://github.com/grpc/grpc-java/issues/2372#issuecomment-258216611
https://groups.google.com/forum/#!topic/grpc-io/gaFmBDOmYE0
https://github.com/grpc/grpc-java/issues/3548

~my gut feeling for this one is that it is a concurrency problem, related with a lot of streams being created & deleted and they're not handled correctly.~

There are comments suggesting that this issue may be related to message frame size too... I'll try to investigate in that area.