### PR TITLE
WIP: bump fs2 reactive streams 0.6.0

### DIFF
--- a/modules/internal/src/main/scala/client/fs2Calls.scala
+++ b/modules/internal/src/main/scala/client/fs2Calls.scala
@@ -18,7 +18,7 @@ package freestyle.rpc
 package internal
 package client
 
-import cats.effect.Effect
+import cats.effect.{ConcurrentEffect, Timer}
 import _root_.fs2._
 import _root_.fs2.interop.reactivestreams._
 import monix.execution.Scheduler
@@ -27,14 +27,14 @@ import monix.reactive.Observable
 
 object fs2Calls {
 
-  def unary[F[_]: Effect, Req, Res](
+  def unary[F[_]: ConcurrentEffect, Req, Res](
       request: Req,
       descriptor: MethodDescriptor[Req, Res],
       channel: Channel,
       options: CallOptions)(implicit S: Scheduler): F[Res] =
     monixCalls.unary(request, descriptor, channel, options)
 
-  def serverStreaming[F[_]: Effect, Req, Res](
+  def serverStreaming[F[_]: ConcurrentEffect: Timer, Req, Res](
       request: Req,
       descriptor: MethodDescriptor[Req, Res],
       channel: Channel,
@@ -44,7 +44,7 @@ object fs2Calls {
       .toReactivePublisher
       .toStream[F]
 
-  def clientStreaming[F[_]: Effect, Req, Res](
+  def clientStreaming[F[_]: ConcurrentEffect: Timer, Req, Res](
       input: Stream[F, Req],
       descriptor: MethodDescriptor[Req, Res],
       channel: Channel,
@@ -56,7 +56,7 @@ object fs2Calls {
       channel,
       options)
 
-  def bidiStreaming[F[_]: Effect, Req, Res](
+  def bidiStreaming[F[_]: ConcurrentEffect: Timer, Req, Res](
       input: Stream[F, Req],
       descriptor: MethodDescriptor[Req, Res],
       channel: Channel,

--- a/modules/internal/src/main/scala/server/fs2Calls.scala
+++ b/modules/internal/src/main/scala/server/fs2Calls.scala
@@ -20,7 +20,7 @@ package server
 
 import _root_.fs2.Stream
 import _root_.fs2.interop.reactivestreams._
-import cats.effect.Effect
+import cats.effect.{ConcurrentEffect, Timer}
 import io.grpc.stub.ServerCalls._
 import io.grpc.stub.StreamObserver
 import monix.execution.Scheduler
@@ -30,12 +30,12 @@ object fs2Calls {
 
   import freestyle.rpc.internal.converters._
 
-  def unaryMethod[F[_]: Effect, Req, Res](
+  def unaryMethod[F[_]: ConcurrentEffect, Req, Res](
       f: Req => F[Res],
       maybeCompression: Option[String]): UnaryMethod[Req, Res] =
     monixCalls.unaryMethod(f, maybeCompression)
 
-  def clientStreamingMethod[F[_]: Effect, Req, Res](
+  def clientStreamingMethod[F[_]: ConcurrentEffect: Timer, Req, Res](
       f: Stream[F, Req] => F[Res],
       maybeCompression: Option[String])(implicit S: Scheduler): ClientStreamingMethod[Req, Res] =
     new ClientStreamingMethod[Req, Res] {
@@ -50,7 +50,7 @@ object fs2Calls {
       }
     }
 
-  def serverStreamingMethod[F[_]: Effect, Req, Res](
+  def serverStreamingMethod[F[_]: ConcurrentEffect: Timer, Req, Res](
       f: Req => Stream[F, Res],
       maybeCompression: Option[String])(implicit S: Scheduler): ServerStreamingMethod[Req, Res] =
     new ServerStreamingMethod[Req, Res] {
@@ -61,7 +61,7 @@ object fs2Calls {
       }
     }
 
-  def bidiStreamingMethod[F[_]: Effect, Req, Res](
+  def bidiStreamingMethod[F[_]: ConcurrentEffect: Timer, Req, Res](
       f: Stream[F, Req] => Stream[F, Res],
       maybeCompression: Option[String])(implicit S: Scheduler): BidiStreamingMethod[Req, Res] =
     new BidiStreamingMethod[Req, Res] {

--- a/modules/internal/src/main/scala/service.scala
+++ b/modules/internal/src/main/scala/service.scala
@@ -99,9 +99,10 @@ trait RPCService {
     val args: Seq[Term.Tuple] = requests.map(_.call)
     q"""
        def bindService[F[_]](implicit
-         F: _root_.cats.effect.Effect[F],
+         F: _root_.cats.effect.ConcurrentEffect[F],
          algebra: $algName[F],
-         S: _root_.monix.execution.Scheduler
+         S: _root_.monix.execution.Scheduler,
+         T: _root_.cats.effect.Timer[F]
        ): _root_.io.grpc.ServerServiceDefinition =
            new _root_.freestyle.rpc.internal.service.GRPCServiceDefBuilder(${Lit.String(
       algName.value)}, ..$args).apply
@@ -121,8 +122,9 @@ trait RPCService {
          channel: _root_.io.grpc.Channel,
          options: _root_.io.grpc.CallOptions = _root_.io.grpc.CallOptions.DEFAULT
        )(implicit
-         F: _root_.cats.effect.Effect[F],
-         S: _root_.monix.execution.Scheduler
+         F: _root_.cats.effect.ConcurrentEffect[F],
+         S: _root_.monix.execution.Scheduler,
+         T: _root_.cats.effect.Timer[F]
        ) extends _root_.io.grpc.stub.AbstractStub[$clientName[F]](channel, options) {
 
           override def build(channel: _root_.io.grpc.Channel, options: _root_.io.grpc.CallOptions): $clientName[F] =
@@ -144,8 +146,9 @@ trait RPCService {
            _root_.freestyle.rpc.client.UsePlaintext()),
          options: _root_.io.grpc.CallOptions = _root_.io.grpc.CallOptions.DEFAULT
        )(implicit
-         F: _root_.cats.effect.Effect[F],
-         S: _root_.monix.execution.Scheduler
+         F: _root_.cats.effect.ConcurrentEffect[F],
+         S: _root_.monix.execution.Scheduler,
+         T: _root_.cats.effect.Timer[F]
        ): $clientName[F] = {
          val managedChannelInterpreter =
            new _root_.freestyle.rpc.client.ManagedChannelInterpreter[F](channelFor, channelConfigList)
@@ -157,8 +160,9 @@ trait RPCService {
          channel: _root_.io.grpc.Channel,
          options: _root_.io.grpc.CallOptions = _root_.io.grpc.CallOptions.DEFAULT
        )(implicit
-         F: _root_.cats.effect.Effect[F],
-         S: _root_.monix.execution.Scheduler
+         F: _root_.cats.effect.ConcurrentEffect[F],
+         S: _root_.monix.execution.Scheduler,
+         T: _root_.cats.effect.Timer[F]
         ): $clientName[F] = new $clientCtor[F](channel, options)
      """
   )

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -21,13 +21,14 @@ object ProjectPlugin extends AutoPlugin {
     lazy val V = new {
       val avro4s: String             = "1.8.3"
       val avrohugger: String         = "1.0.0-RC10"
-      val catsEffect: String         = "0.10.1"
+      val catsEffect: String         = "1.0.0-RC2"
       val circe: String              = "0.9.3"
       val frees: String              = "0.8.1"
       val fs2ReactiveStreams: String = "0.6.0"
       val grpc: String               = "1.11.0"
       val log4s: String              = "1.6.1"
       val logback: String            = "1.2.3"
+      val monix: String              = "3.0.0-RC1"
       val nettySSL: String           = "2.0.8.Final"
       val pbdirect: String           = "0.1.0"
       val prometheus: String         = "0.3.0"
@@ -52,7 +53,7 @@ object ProjectPlugin extends AutoPlugin {
       libraryDependencies ++= Seq(
         %%("cats-effect", V.catsEffect),
         %("grpc-stub", V.grpc),
-        %%("monix"),
+        %%("monix", V.monix) excludeAll ("org.typelevel" %% "cats-effect"),
         %%("fs2-reactive-streams", V.fs2ReactiveStreams),
         %%("pbdirect", V.pbdirect),
         %%("avro4s", V.avro4s),
@@ -142,7 +143,7 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val exampleRouteguideRuntimeSettings: Seq[Def.Setting[_]] = Seq(
       libraryDependencies ++= Seq(
-        %%("monix")
+        %%("monix", V.monix) excludeAll ("org.typelevel" %% "cats-effect")
       )
     )
 
@@ -158,7 +159,7 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val exampleTodolistRuntimeSettings: Seq[Def.Setting[_]] = Seq(
       libraryDependencies ++= Seq(
-        %%("monix")
+        %%("monix", V.monix) excludeAll ("org.typelevel" %% "cats-effect")
       )
     )
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -24,7 +24,7 @@ object ProjectPlugin extends AutoPlugin {
       val catsEffect: String         = "0.10.1"
       val circe: String              = "0.9.3"
       val frees: String              = "0.8.1"
-      val fs2ReactiveStreams: String = "0.5.1"
+      val fs2ReactiveStreams: String = "0.6.0"
       val grpc: String               = "1.11.0"
       val log4s: String              = "1.6.1"
       val logback: String            = "1.2.3"


### PR DESCRIPTION
# WIP: Do  not merge (waiting for monix to release a version depending on cats-effect 1.0.0-*)

- update fs-reactive-streams to 0.6.0
- migrate changes to adopt new fs2-rs (change `Effect` with `ConcurrentEffect`)
- bump monix to 3.0.0-RC1

---

There is a binary incompatibility in monix right now.  `monix:3.0.0-RC1` (current last version) depends on `cats-effect:0.10`, which is binary incompatible with `cats-effect:1.0.0-RC2` (the version `fs2-reactive-streams:0.6.0` depends on.

I don't think we can advance much more on this, In the beginning I thought that excluding monix' transitive dep on cats-effect would help but nope.

FIXES #303