### PR TITLE
WIP: referentially transparent clients

### DIFF
--- a/modules/client-netty/src/main/scala/NettyChannelConfig.scala
+++ b/modules/client-netty/src/main/scala/NettyChannelConfig.scala
@@ -24,7 +24,7 @@ import io.grpc.netty.NegotiationType
 import io.netty.channel.{Channel, ChannelOption, EventLoopGroup}
 import io.netty.handler.ssl.SslContext
 
-sealed trait NettyChannelConfig                                         extends ManagedChannelConfig
+sealed trait NettyChannelConfig                                         extends Product with Serializable
 final case class NettyChannelType(channelType: Class[_ <: Channel])     extends NettyChannelConfig
 final case class NettyWithOption[T](option: ChannelOption[T], value: T) extends NettyChannelConfig
 final case class NettyNegotiationType(`type`: NegotiationType)          extends NettyChannelConfig

--- a/modules/client/src/main/scala/ManagedChannelConfig.scala
+++ b/modules/client/src/main/scala/ManagedChannelConfig.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.{Executor, TimeUnit}
 
 import io.grpc._
 
-trait ManagedChannelConfig                       extends Product with Serializable
+sealed trait ManagedChannelConfig                extends Product with Serializable
 case object DirectExecutor                       extends ManagedChannelConfig
 final case class SetExecutor(executor: Executor) extends ManagedChannelConfig
 final case class AddInterceptorList(interceptors: List[ClientInterceptor])

--- a/modules/client/src/main/scala/package.scala
+++ b/modules/client/src/main/scala/package.scala
@@ -16,6 +16,9 @@
 
 package freestyle.rpc
 
+import cats.effect.Sync
+import cats.syntax.flatMap._
+import cats.syntax.functor._
 import cats.data.Kleisli
 import cats.~>
 
@@ -24,49 +27,50 @@ import io.grpc._
 
 package object client {
 
-  type ManagedChannelOps[F[_], A] = Kleisli[F, ManagedChannel, A]
+  type ManagedChannelOps[F[_], A] = Kleisli[F, F[ManagedChannel], A]
 
   class ManagedChannelInterpreter[F[_]](
       initConfig: ChannelFor,
-      configList: List[ManagedChannelConfig])
-      extends (Kleisli[F, ManagedChannel, ?] ~> F) {
+      configList: List[ManagedChannelConfig])(implicit F: Sync[F]) {
 
     def build[T <: ManagedChannelBuilder[T]](
         initConfig: ChannelFor,
-        configList: List[ManagedChannelConfig]): ManagedChannel = {
-      val builder: T = initConfig match {
+        configList: List[ManagedChannelConfig]): F[ManagedChannel] = {
+
+      val builder: F[T] = initConfig match {
         case ChannelForAddress(name, port) =>
-          ManagedChannelBuilder.forAddress(name, port).asInstanceOf[T]
-        case ChannelForTarget(target) => ManagedChannelBuilder.forTarget(target).asInstanceOf[T]
+          F.delay(ManagedChannelBuilder.forAddress(name, port).asInstanceOf[T])
+        case ChannelForTarget(target) =>
+          F.delay(ManagedChannelBuilder.forTarget(target).asInstanceOf[T])
         case e =>
-          throw new IllegalArgumentException(s"ManagedChannel not supported for $e")
+          F.raiseError(new IllegalArgumentException(s"ManagedChannel not supported for $e"))
       }
 
-      configList
-        .foldLeft(builder) { (acc, cfg) =>
-          ManagedChannelB(acc)(cfg)
-        }
-        .build()
+      for {
+        b          <- builder
+        configured <- F.delay(configList.foldLeft(b)(configureChannel))
+        built      <- F.delay(configured.build())
+      } yield built
     }
 
-    override def apply[A](fa: Kleisli[F, ManagedChannel, A]): F[A] =
+    def apply[A](fa: ManagedChannelOps[F, A]): F[A] =
       fa(build(initConfig, configList))
   }
 
-  def ManagedChannelB[T <: ManagedChannelBuilder[T]](
-      mcb: T): PartialFunction[ManagedChannelConfig, T] = {
-    case DirectExecutor                    => mcb.directExecutor()
-    case SetExecutor(executor)             => mcb.executor(executor)
-    case AddInterceptorList(interceptors)  => mcb.intercept(interceptors.asJava)
-    case AddInterceptor(interceptors @ _*) => mcb.intercept(interceptors: _*)
-    case UserAgent(userAgent)              => mcb.userAgent(userAgent)
-    case OverrideAuthority(authority)      => mcb.overrideAuthority(authority)
-    case UsePlaintext()                    => mcb.usePlaintext()
-    case NameResolverFactory(rf)           => mcb.nameResolverFactory(rf)
-    case LoadBalancerFactory(lbf)          => mcb.loadBalancerFactory(lbf)
-    case SetDecompressorRegistry(registry) => mcb.decompressorRegistry(registry)
-    case SetCompressorRegistry(registry)   => mcb.compressorRegistry(registry)
-    case SetIdleTimeout(value, unit)       => mcb.idleTimeout(value, unit)
-    case SetMaxInboundMessageSize(max)     => mcb.maxInboundMessageSize(max)
-  }
+  def configureChannel[T <: ManagedChannelBuilder[T]](mcb: T, conf: ManagedChannelConfig): T =
+    conf match {
+      case DirectExecutor                    => mcb.directExecutor()
+      case SetExecutor(executor)             => mcb.executor(executor)
+      case AddInterceptorList(interceptors)  => mcb.intercept(interceptors.asJava)
+      case AddInterceptor(interceptors @ _*) => mcb.intercept(interceptors: _*)
+      case UserAgent(userAgent)              => mcb.userAgent(userAgent)
+      case OverrideAuthority(authority)      => mcb.overrideAuthority(authority)
+      case UsePlaintext()                    => mcb.usePlaintext()
+      case NameResolverFactory(rf)           => mcb.nameResolverFactory(rf)
+      case LoadBalancerFactory(lbf)          => mcb.loadBalancerFactory(lbf)
+      case SetDecompressorRegistry(registry) => mcb.decompressorRegistry(registry)
+      case SetCompressorRegistry(registry)   => mcb.compressorRegistry(registry)
+      case SetIdleTimeout(value, unit)       => mcb.idleTimeout(value, unit)
+      case SetMaxInboundMessageSize(max)     => mcb.maxInboundMessageSize(max)
+    }
 }

--- a/modules/client/src/test/scala/ManagedChannelInterpreterTests.scala
+++ b/modules/client/src/test/scala/ManagedChannelInterpreterTests.scala
@@ -17,12 +17,10 @@
 package freestyle.rpc
 package client
 
+import cats.effect.IO
 import cats.data.Kleisli
 import freestyle.rpc.common.SC
 import io.grpc.ManagedChannel
-
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, Future}
 
 abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
 
@@ -37,11 +35,12 @@ abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
       val channelConfigList: List[ManagedChannelConfig] = List(UsePlaintext())
 
       val managedChannelInterpreter =
-        new ManagedChannelInterpreter[Future](channelFor, channelConfigList)
+        new ManagedChannelInterpreter[IO](channelFor, channelConfigList)
 
-      val mc: ManagedChannel = managedChannelInterpreter.build(channelFor, channelConfigList)
+      val mc: ManagedChannel =
+        managedChannelInterpreter.build(channelFor, channelConfigList).unsafeRunSync
 
-      mc shouldBe an[ManagedChannel]
+      mc shouldBe a[ManagedChannel]
 
       mc.shutdownNow()
     }
@@ -53,9 +52,10 @@ abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
       val channelConfigList: List[ManagedChannelConfig] = List(UsePlaintext())
 
       val managedChannelInterpreter =
-        new ManagedChannelInterpreter[Future](channelFor, channelConfigList)
+        new ManagedChannelInterpreter[IO](channelFor, channelConfigList)
 
-      val mc: ManagedChannel = managedChannelInterpreter.build(channelFor, channelConfigList)
+      val mc: ManagedChannel =
+        managedChannelInterpreter.build(channelFor, channelConfigList).unsafeRunSync
 
       mc shouldBe a[ManagedChannel]
 
@@ -69,15 +69,12 @@ abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
       val channelConfigList: List[ManagedChannelConfig] = List(UsePlaintext())
 
       val managedChannelInterpreter =
-        new ManagedChannelInterpreter[Future](channelFor, channelConfigList)
+        new ManagedChannelInterpreter[IO](channelFor, channelConfigList)
 
-      val kleisli: ManagedChannelOps[Future, String] =
-        Kleisli[Future, ManagedChannel, String]((mc: ManagedChannel) => {
-          mc.shutdownNow()
-          Future.successful(foo)
-        })
+      val kleisli: ManagedChannelOps[IO, String] =
+        Kleisli.liftF(IO(foo))
 
-      Await.result(managedChannelInterpreter[String](kleisli), Duration.Inf) shouldBe foo
+      managedChannelInterpreter[String](kleisli).unsafeRunSync shouldBe foo
     }
 
     "build a io.grpc.ManagedChannel based on any configuration combination" in {
@@ -87,27 +84,14 @@ abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
       val channelConfigList: List[ManagedChannelConfig] = managedChannelConfigAllList
 
       val managedChannelInterpreter =
-        new ManagedChannelInterpreter[Future](channelFor, channelConfigList)
+        new ManagedChannelInterpreter[IO](channelFor, channelConfigList)
 
-      val mc: ManagedChannel = managedChannelInterpreter.build(channelFor, channelConfigList)
+      val mc: ManagedChannel =
+        managedChannelInterpreter.build(channelFor, channelConfigList).unsafeRunSync
 
       mc shouldBe a[ManagedChannel]
 
       mc.shutdownNow()
-    }
-
-    "throw an exception when configuration is not recognized" in {
-
-      val channelFor: ChannelFor = ChannelForAddress(SC.host, SC.port)
-
-      case object Unexpected extends ManagedChannelConfig
-      val channelConfigList: List[ManagedChannelConfig] = List(Unexpected)
-
-      val managedChannelInterpreter =
-        new ManagedChannelInterpreter[Future](channelFor, channelConfigList)
-
-      a[MatchError] shouldBe thrownBy(
-        managedChannelInterpreter.build(channelFor, channelConfigList))
     }
 
     "throw an exception when ChannelFor is not recognized" in {
@@ -115,10 +99,10 @@ abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
       val channelFor: ChannelFor = ChannelForPort(SC.port)
 
       val managedChannelInterpreter =
-        new ManagedChannelInterpreter[Future](channelFor, Nil)
+        new ManagedChannelInterpreter[IO](channelFor, Nil)
 
       an[IllegalArgumentException] shouldBe thrownBy(
-        managedChannelInterpreter.build(channelFor, Nil))
+        managedChannelInterpreter.build(channelFor, Nil).unsafeRunSync)
     }
   }
 }

--- a/modules/examples/routeguide/client/src/main/scala-io/implicitsio.scala
+++ b/modules/examples/routeguide/client/src/main/scala-io/implicitsio.scala
@@ -24,7 +24,7 @@ import example.routeguide.client.runtime._
 
 trait ClientIOImplicits extends RouteGuide with ClientConf {
 
-  implicit val routeGuideServiceClient: RouteGuideService.Client[IO] =
+  implicit val routeGuideServiceClient: IO[RouteGuideService.Client[IO]] =
     RouteGuideService.client[IO](channelFor)
 
   implicit val routeGuideClientHandler: RouteGuideClientHandler[IO] =

--- a/modules/examples/routeguide/client/src/main/scala-task/implicitstask.scala
+++ b/modules/examples/routeguide/client/src/main/scala-task/implicitstask.scala
@@ -24,7 +24,7 @@ import monix.eval.Task
 
 trait ClientTaskImplicits extends RouteGuide with ClientConf {
 
-  implicit val routeGuideServiceClient: RouteGuideService.Client[Task] =
+  implicit val routeGuideServiceClient: Task[RouteGuideService.Client[Task]] =
     RouteGuideService.client[Task](channelFor)
 
   implicit val routeGuideClientHandler: RouteGuideClientHandler[Task] =

--- a/modules/server/src/test/scala/avro/Utils.scala
+++ b/modules/server/src/test/scala/avro/Utils.scala
@@ -299,7 +299,7 @@ object Utils extends CommonUtils {
     // Client Runtime Configuration //
     //////////////////////////////////
 
-    implicit val freesRPCServiceClient: service.RPCService.Client[ConcurrentMonad] =
+    implicit val freesRPCServiceClient: ConcurrentMonad[service.RPCService.Client[ConcurrentMonad]] =
       service.RPCService.client[ConcurrentMonad](createChannelFor)
 
   }

--- a/modules/server/src/test/scala/fs2/Utils.scala
+++ b/modules/server/src/test/scala/fs2/Utils.scala
@@ -171,7 +171,7 @@ object Utils extends CommonUtils {
     // Client Runtime Configuration //
     //////////////////////////////////
 
-    implicit val freesRPCServiceClient: RPCService.Client[ConcurrentMonad] =
+    implicit val freesRPCServiceClient: ConcurrentMonad[RPCService.Client[ConcurrentMonad]] =
       RPCService.client[ConcurrentMonad](createChannelFor)
 
   }

--- a/modules/server/src/test/scala/protocol/RPCBigDecimalTests.scala
+++ b/modules/server/src/test/scala/protocol/RPCBigDecimalTests.scala
@@ -77,8 +77,8 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
     "be able to serialize and deserialize BigDecimal using proto format" in {
 
       withServerChannel(RPCServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: RPCServiceDef.Client[ConcurrentMonad] =
-          RPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+        val client: ConcurrentMonad[RPCServiceDef.Client[ConcurrentMonad]] =
+          RPCServiceDef.clientFromChannel[ConcurrentMonad](IO.pure(sc.channel))
 
         check {
           forAll { bd: BigDecimal =>
@@ -94,7 +94,7 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
       withServerChannel(RPCServiceDef.bindService[ConcurrentMonad]) { sc =>
         val client: RPCServiceDef.Client[ConcurrentMonad] =
-          RPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+          RPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll { (bd: BigDecimal, s: String) =>
@@ -113,7 +113,7 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
       withServerChannel(RPCServiceDef.bindService[ConcurrentMonad]) { sc =>
         val client: RPCServiceDef.Client[ConcurrentMonad] =
-          RPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+          RPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll { bd: BigDecimal =>
@@ -129,7 +129,7 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
       withServerChannel(RPCServiceDef.bindService[ConcurrentMonad]) { sc =>
         val client: RPCServiceDef.Client[ConcurrentMonad] =
-          RPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+          RPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll { (bd: BigDecimal, s: String) =>
@@ -148,7 +148,7 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
       withServerChannel(RPCServiceDef.bindService[ConcurrentMonad]) { sc =>
         val client: RPCServiceDef.Client[ConcurrentMonad] =
-          RPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+          RPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll { bd: BigDecimal =>
@@ -164,7 +164,7 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
       withServerChannel(RPCServiceDef.bindService[ConcurrentMonad]) { sc =>
         val client: RPCServiceDef.Client[ConcurrentMonad] =
-          RPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+          RPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll { (bd: BigDecimal, s: String) =>

--- a/modules/server/src/test/scala/protocol/RPCJavaTimeTests.scala
+++ b/modules/server/src/test/scala/protocol/RPCJavaTimeTests.scala
@@ -90,8 +90,8 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDate using proto format" in {
 
       withServerChannel(RPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: RPCDateServiceDef.Client[ConcurrentMonad] =
-          RPCDateServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+        val client: ConcurrentMonad[RPCDateServiceDef.Client[ConcurrentMonad]] =
+          RPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
@@ -107,8 +107,8 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDateTime using proto format" in {
 
       withServerChannel(RPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: RPCDateServiceDef.Client[ConcurrentMonad] =
-          RPCDateServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+        val client: ConcurrentMonad[RPCDateServiceDef.Client[ConcurrentMonad]] =
+          RPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
@@ -124,8 +124,8 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDate and LocalDateTime in a Request using proto format" in {
 
       withServerChannel(RPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: RPCDateServiceDef.Client[ConcurrentMonad] =
-          RPCDateServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+        val client: ConcurrentMonad[RPCDateServiceDef.Client[ConcurrentMonad]] =
+          RPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
@@ -147,8 +147,8 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDate using avro format" in {
 
       withServerChannel(RPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: RPCDateServiceDef.Client[ConcurrentMonad] =
-          RPCDateServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+        val client: ConcurrentMonad[RPCDateServiceDef.Client[ConcurrentMonad]] =
+          RPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
@@ -164,8 +164,8 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDateTime using avro format" in {
 
       withServerChannel(RPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: RPCDateServiceDef.Client[ConcurrentMonad] =
-          RPCDateServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+        val client: ConcurrentMonad[RPCDateServiceDef.Client[ConcurrentMonad]] =
+          RPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
@@ -181,8 +181,8 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDate and LocalDateTime in a Request using avro format" in {
 
       withServerChannel(RPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: RPCDateServiceDef.Client[ConcurrentMonad] =
-          RPCDateServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+        val client: ConcurrentMonad[RPCDateServiceDef.Client[ConcurrentMonad]] =
+          RPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
@@ -204,8 +204,8 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDate using avro format with schema" in {
 
       withServerChannel(RPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: RPCDateServiceDef.Client[ConcurrentMonad] =
-          RPCDateServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+        val client: ConcurrentMonad[RPCDateServiceDef.Client[ConcurrentMonad]] =
+          RPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
@@ -221,8 +221,8 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDateTime using avro format with schema" in {
 
       withServerChannel(RPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: RPCDateServiceDef.Client[ConcurrentMonad] =
-          RPCDateServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+        val client: ConcurrentMonad[RPCDateServiceDef.Client[ConcurrentMonad]] =
+          RPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
@@ -238,8 +238,8 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDate and LocalDateTime in a Request using avro format with schema" in {
 
       withServerChannel(RPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: RPCDateServiceDef.Client[ConcurrentMonad] =
-          RPCDateServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+        val client: ConcurrentMonad[RPCDateServiceDef.Client[ConcurrentMonad]] =
+          RPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {

--- a/modules/server/src/test/scala/protocol/Utils.scala
+++ b/modules/server/src/test/scala/protocol/Utils.scala
@@ -541,7 +541,7 @@ object Utils extends CommonUtils {
     // Client Runtime Configuration //
     //////////////////////////////////
 
-    implicit val freesRPCServiceClient: RPCService.Client[ConcurrentMonad] =
+    implicit val freesRPCServiceClient: ConcurrentMonad[RPCService.Client[ConcurrentMonad]] =
       RPCService.client[ConcurrentMonad](createChannelFor)
 
   }

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -21,7 +21,7 @@ object ProjectPlugin extends AutoPlugin {
     lazy val V = new {
       val avro4s: String             = "1.8.3"
       val avrohugger: String         = "1.0.0-RC10"
-      val catsEffect: String         = "0.10.1"
+      val catsEffect: String         = "1.0.0-RC2"
       val circe: String              = "0.9.3"
       val frees: String              = "0.8.1"
       val fs2ReactiveStreams: String = "0.5.1"


### PR DESCRIPTION
# WIP: Do not merge

Currently is not building because we're still depending on monix to release a cats-effect `1.0.0-RC2` compatible version. Also some more work needs to be done finishing the integration.

Waiting for monix/monix#681 to be released

---

This PR:
- bumps cats-effect to `1.0.0-RC2` (as #307 does)
- purifies the way we're instantiating GRPC's `ManagedChannel`s
- makes the instantiation of `Client`s more referentially transparent by bracketing over `F[Channel]` and `shutdown()` ing after use.
- seals `ManageChannelConfig`
- makes `NettyChannelConfig` not inherit `ManageChannelConfig` (it can't now)
- uses an `Either` for configuring netty clients (see [here](https://github.com/frees-io/freestyle-rpc/compare/ppg/305-ref-transparency-clients?expand=1#diff-38417b33d7ce2f25019cfcba711b5d0cR27))
- integrates those changes in the rest of the codebase


FIXES #305 