### PR TITLE
Releases 0.16.0

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.16.0-SNAPSHOT"
+version in ThisBuild := "0.16.0"


### PR DESCRIPTION
This PR release `mu` **0.16.0**.

It publishes the same binary artifacts as `0.15.1`, but in this case using the new project name.