### PR TITLE
Update dependencies: `io.circe`, `io.grpc`, netty and avro4s

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -40,7 +40,7 @@ object ProjectPlugin extends AutoPlugin {
       val logback: String            = "1.2.3"
       val monix: String              = "3.0.0-RC1"
       val monocle: String            = "1.5.1-cats"
-      val nettySSL: String           = "2.0.12.Final"
+      val nettySSL: String           = "2.0.18.Final"
       val paradise: String           = "2.1.1"
       val pbdirect: String           = "0.1.0"
       val prometheus: String         = "0.5.0"

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -26,16 +26,16 @@ object ProjectPlugin extends AutoPlugin {
   object autoImport {
 
     lazy val V = new {
-      val avro4s: String             = "1.8.3"
+      val avro4s: String             = "1.9.0"
       val avrohugger: String         = "1.0.0-RC14"
       val betterMonadicFor: String   = "0.2.4"
       val catsEffect: String         = "0.10.1"
-      val circe: String              = "0.9.3"
+      val circe: String              = "0.10.0"
       val frees: String              = "0.8.2"
       val fs2: String                = "0.10.6"
       val fs2ReactiveStreams: String = "0.5.1"
       val jodaTime: String           = "2.10"
-      val grpc: String               = "1.15.0"
+      val grpc: String               = "1.15.1"
       val log4s: String              = "1.6.1"
       val logback: String            = "1.2.3"
       val monix: String              = "3.0.0-RC1"


### PR DESCRIPTION
This PR has updates on the dependencies that didn't require code changes. From what I've understood the other ones require some more code changes that will be best on separate PRs to be more contained. 

I've updated `avro4s` to the minor version referenced on the issue (#452), but to the major also requires some bigger code changes, I believe it is also best to separate it.

This fixes #437, #438, #439, #447, #450, #453, #454 , #455, #456, #457, #458, #459, #460 and #461