### PR TITLE
No need to liftIO in GrpcServer

### DIFF
--- a/modules/server/src/main/scala/GrpcServer.scala
+++ b/modules/server/src/main/scala/GrpcServer.scala
@@ -92,7 +92,7 @@ object GrpcServer {
       })
     }
 
-    S.start() *> F.liftIO(IO.async[Unit](cb => shutdownEventually(cb)))
+    S.start() *> F.async[Unit](cb => shutdownEventually(cb))
   }
 
   def default[F[_]](port: Int, configList: List[GrpcConfig])(


### PR DESCRIPTION
Not sure why I did a `F.liftIO(IO.async(...))` in my last pr. Instead I've just changed this to use `F`'s `async` method instead of `IO`. 