### PR TITLE
Uses fs2-grpc for the fs2 integration

### DIFF
--- a/modules/internal/src/main/scala/client/fs2Calls.scala
+++ b/modules/internal/src/main/scala/client/fs2Calls.scala
@@ -18,58 +18,47 @@ package mu.rpc
 package internal
 package client
 
-import cats.effect.{ConcurrentEffect, Effect}
-import _root_.fs2._
-import _root_.fs2.interop.reactivestreams._
+import cats.effect.ConcurrentEffect
+import cats.syntax.flatMap._
+import fs2.Stream
+import io.grpc.{CallOptions, Channel, Metadata, MethodDescriptor}
+import org.lyranthe.fs2_grpc.java_runtime.client.Fs2ClientCall
 
 import scala.concurrent.ExecutionContext
-import io.grpc.{CallOptions, Channel, MethodDescriptor}
-import monix.execution.Scheduler
-import monix.reactive.Observable
 
 object fs2Calls {
 
-  def unary[F[_]: Effect, Req, Res](
+  def unary[F[_]: ConcurrentEffect, Req, Res](
       request: Req,
       descriptor: MethodDescriptor[Req, Res],
       channel: Channel,
       options: CallOptions)(implicit EC: ExecutionContext): F[Res] =
-    monixCalls.unary(request, descriptor, channel, options)
+    Fs2ClientCall[F](channel, descriptor, options)
+      .flatMap(_.unaryToUnaryCall(request, new Metadata()))
 
   def serverStreaming[F[_]: ConcurrentEffect, Req, Res](
       request: Req,
       descriptor: MethodDescriptor[Req, Res],
       channel: Channel,
       options: CallOptions)(implicit EC: ExecutionContext): Stream[F, Res] =
-    monixCalls
-      .serverStreaming(request, descriptor, channel, options)
-      .toReactivePublisher(Scheduler(EC))
-      .toStream[F]
+    Stream
+      .eval(Fs2ClientCall[F](channel, descriptor, options))
+      .flatMap(_.unaryToStreamingCall(request, new Metadata()))
 
   def clientStreaming[F[_]: ConcurrentEffect, Req, Res](
       input: Stream[F, Req],
       descriptor: MethodDescriptor[Req, Res],
       channel: Channel,
       options: CallOptions)(implicit EC: ExecutionContext): F[Res] =
-    monixCalls.clientStreaming(
-      Observable
-        .fromReactivePublisher(input.toUnicastPublisher),
-      descriptor,
-      channel,
-      options)
+    Fs2ClientCall[F](channel, descriptor, options)
+      .flatMap(_.streamingToUnaryCall(input, new Metadata()))
 
   def bidiStreaming[F[_]: ConcurrentEffect, Req, Res](
       input: Stream[F, Req],
       descriptor: MethodDescriptor[Req, Res],
       channel: Channel,
       options: CallOptions)(implicit EC: ExecutionContext): Stream[F, Res] =
-    monixCalls
-      .bidiStreaming(
-        Observable
-          .fromReactivePublisher(input.toUnicastPublisher),
-        descriptor,
-        channel,
-        options)
-      .toReactivePublisher(Scheduler(EC))
-      .toStream[F]
+    Stream
+      .eval(Fs2ClientCall[F](channel, descriptor, options))
+      .flatMap(_.streamingToStreamingCall(input, new Metadata()))
 }

--- a/modules/internal/src/main/scala/server/fs2Calls.scala
+++ b/modules/internal/src/main/scala/server/fs2Calls.scala
@@ -18,68 +18,37 @@ package mu.rpc
 package internal
 package server
 
-import _root_.fs2.Stream
-import _root_.fs2.interop.reactivestreams._
-import cats.effect.{ConcurrentEffect, Effect}
-import io.grpc.stub.ServerCalls._
-import io.grpc.stub.StreamObserver
-import monix.execution.Scheduler
+import fs2.Stream
+import cats.effect.ConcurrentEffect
+import io.grpc.ServerCallHandler
+import org.lyranthe.fs2_grpc.java_runtime.server.Fs2ServerCallHandler
 
 import scala.concurrent.ExecutionContext
-import monix.reactive.Observable
 
 object fs2Calls {
 
-  import mu.rpc.internal.converters._
-
-  def unaryMethod[F[_]: Effect, Req, Res](
+  def unaryMethod[F[_]: ConcurrentEffect, Req, Res](
       f: Req => F[Res],
-      maybeCompression: Option[String]): UnaryMethod[Req, Res] =
-    monixCalls.unaryMethod(f, maybeCompression)
+      maybeCompression: Option[String])(
+      implicit EC: ExecutionContext): ServerCallHandler[Req, Res] =
+    Fs2ServerCallHandler[F].unaryToUnaryCall[Req, Res]((req, _) => f(req))
 
   def clientStreamingMethod[F[_]: ConcurrentEffect, Req, Res](
       f: Stream[F, Req] => F[Res],
       maybeCompression: Option[String])(
-      implicit EC: ExecutionContext): ClientStreamingMethod[Req, Res] =
-    new ClientStreamingMethod[Req, Res] {
-
-      override def invoke(responseObserver: StreamObserver[Res]): StreamObserver[Req] = {
-        addCompression(responseObserver, maybeCompression)
-        transformStreamObserver[Req, Res](
-          inputObservable =>
-            Observable.from(f(inputObservable.toReactivePublisher(Scheduler(EC)).toStream[F])),
-          responseObserver
-        )
-      }
-    }
+      implicit EC: ExecutionContext): ServerCallHandler[Req, Res] =
+    Fs2ServerCallHandler[F].streamingToUnaryCall[Req, Res]((stream, _) => f(stream))
 
   def serverStreamingMethod[F[_]: ConcurrentEffect, Req, Res](
       f: Req => Stream[F, Res],
       maybeCompression: Option[String])(
-      implicit EC: ExecutionContext): ServerStreamingMethod[Req, Res] =
-    new ServerStreamingMethod[Req, Res] {
-
-      override def invoke(request: Req, responseObserver: StreamObserver[Res]): Unit = {
-        addCompression(responseObserver, maybeCompression)
-        f(request).toUnicastPublisher.subscribe(responseObserver.toSubscriber.toReactive)
-      }
-    }
+      implicit EC: ExecutionContext): ServerCallHandler[Req, Res] =
+    Fs2ServerCallHandler[F].unaryToStreamingCall[Req, Res]((req, _) => f(req))
 
   def bidiStreamingMethod[F[_]: ConcurrentEffect, Req, Res](
       f: Stream[F, Req] => Stream[F, Res],
       maybeCompression: Option[String])(
-      implicit EC: ExecutionContext): BidiStreamingMethod[Req, Res] =
-    new BidiStreamingMethod[Req, Res] {
-
-      override def invoke(responseObserver: StreamObserver[Res]): StreamObserver[Req] = {
-        addCompression(responseObserver, maybeCompression)
-        transformStreamObserver[Req, Res](
-          (inputObservable: Observable[Req]) =>
-            Observable.fromReactivePublisher(
-              f(inputObservable.toReactivePublisher(Scheduler(EC)).toStream[F]).toUnicastPublisher),
-          responseObserver
-        )
-      }
-    }
+      implicit EC: ExecutionContext): ServerCallHandler[Req, Res] =
+    Fs2ServerCallHandler[F].streamingToStreamingCall[Req, Res]((stream, _) => f(stream))
 
 }

--- a/modules/server/src/test/scala/fs2/RPCTests.scala
+++ b/modules/server/src/test/scala/fs2/RPCTests.scala
@@ -88,9 +88,9 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
       clientProgram("SRE").compile.toList
         .unsafeRunSync() shouldBe List(C("INVALID_ARGUMENT: SRE", a1))
       clientProgram("RTE").compile.toList
-        .unsafeRunSync() shouldBe List(C("UNKNOWN", a1)) //todo: consider preserving the exception as is done for unary
+        .unsafeRunSync() shouldBe List(C("INTERNAL: RTE", a1))
       clientProgram("Thrown").compile.toList
-        .unsafeRunSync() shouldBe List(C("UNKNOWN", a1))
+        .unsafeRunSync() shouldBe List(C("INTERNAL: Thrown", a1))
     }
 
     "be able to run client streaming services" in {
@@ -101,8 +101,6 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
     }
 
     "be able to run client bidirectional streaming services" in {
-
-//      ignoreOnTravis("TODO: restore once https://github.com/higherkindness/mu/issues/164 is fixed")
 
       muAvroRPCServiceClient
         .biStreaming(Stream.fromIterator[ConcurrentMonad, E](eList.iterator))
@@ -115,8 +113,6 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
     "be able to run client bidirectional streaming services with avro schema" in {
 
-//      ignoreOnTravis("TODO: restore once https://github.com/higherkindness/mu/issues/164 is fixed")
-
       muAvroWithSchemaRPCServiceClient
         .biStreamingWithSchema(Stream.fromIterator[ConcurrentMonad, E](eList.iterator))
         .compile
@@ -127,8 +123,6 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
     }
 
     "be able to run multiple rpc services" in {
-
-//      ignoreOnTravis("TODO: restore once https://github.com/higherkindness/mu/issues/164 is fixed")
 
       val tuple =
         (
@@ -188,8 +182,6 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
     "be able to run client bidirectional streaming services" in {
 
-//      ignoreOnTravis("TODO: restore once https://github.com/higherkindness/mu/issues/164 is fixed")
-
       muCompressedAvroRPCServiceClient
         .biStreamingCompressed(Stream.fromIterator[ConcurrentMonad, E](eList.iterator))
         .compile
@@ -201,8 +193,6 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
     "be able to run client bidirectional streaming services with avro schema" in {
 
-//      ignoreOnTravis("TODO: restore once https://github.com/higherkindness/mu/issues/164 is fixed")
-
       muCompressedAvroWithSchemaRPCServiceClient
         .biStreamingCompressedWithSchema(Stream.fromIterator[ConcurrentMonad, E](eList.iterator))
         .compile
@@ -213,8 +203,6 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
     }
 
     "be able to run multiple rpc services" in {
-
-//      ignoreOnTravis("TODO: restore once https://github.com/higherkindness/mu/issues/164 is fixed")
 
       val tuple =
         (

--- a/modules/server/src/test/scala/fs2/RPCTests.scala
+++ b/modules/server/src/test/scala/fs2/RPCTests.scala
@@ -102,7 +102,7 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
     "be able to run client bidirectional streaming services" in {
 
-      ignoreOnTravis("TODO: restore once https://github.com/higherkindness/mu/issues/164 is fixed")
+//      ignoreOnTravis("TODO: restore once https://github.com/higherkindness/mu/issues/164 is fixed")
 
       muAvroRPCServiceClient
         .biStreaming(Stream.fromIterator[ConcurrentMonad, E](eList.iterator))
@@ -115,7 +115,7 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
     "be able to run client bidirectional streaming services with avro schema" in {
 
-      ignoreOnTravis("TODO: restore once https://github.com/higherkindness/mu/issues/164 is fixed")
+//      ignoreOnTravis("TODO: restore once https://github.com/higherkindness/mu/issues/164 is fixed")
 
       muAvroWithSchemaRPCServiceClient
         .biStreamingWithSchema(Stream.fromIterator[ConcurrentMonad, E](eList.iterator))
@@ -128,7 +128,7 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
     "be able to run multiple rpc services" in {
 
-      ignoreOnTravis("TODO: restore once https://github.com/higherkindness/mu/issues/164 is fixed")
+//      ignoreOnTravis("TODO: restore once https://github.com/higherkindness/mu/issues/164 is fixed")
 
       val tuple =
         (
@@ -188,7 +188,7 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
     "be able to run client bidirectional streaming services" in {
 
-      ignoreOnTravis("TODO: restore once https://github.com/higherkindness/mu/issues/164 is fixed")
+//      ignoreOnTravis("TODO: restore once https://github.com/higherkindness/mu/issues/164 is fixed")
 
       muCompressedAvroRPCServiceClient
         .biStreamingCompressed(Stream.fromIterator[ConcurrentMonad, E](eList.iterator))
@@ -201,7 +201,7 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
     "be able to run client bidirectional streaming services with avro schema" in {
 
-      ignoreOnTravis("TODO: restore once https://github.com/higherkindness/mu/issues/164 is fixed")
+//      ignoreOnTravis("TODO: restore once https://github.com/higherkindness/mu/issues/164 is fixed")
 
       muCompressedAvroWithSchemaRPCServiceClient
         .biStreamingCompressedWithSchema(Stream.fromIterator[ConcurrentMonad, E](eList.iterator))
@@ -214,7 +214,7 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
     "be able to run multiple rpc services" in {
 
-      ignoreOnTravis("TODO: restore once https://github.com/higherkindness/mu/issues/164 is fixed")
+//      ignoreOnTravis("TODO: restore once https://github.com/higherkindness/mu/issues/164 is fixed")
 
       val tuple =
         (

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -68,7 +68,8 @@ object ProjectPlugin extends AutoPlugin {
         %%("avro4s", V.avro4s),
         %%("log4s", V.log4s),
         "org.scala-lang"         % "scala-compiler" % scalaVersion.value,
-        %%("scalamockScalatest") % Test
+        "org.lyranthe.fs2-grpc" %% "java-runtime" % "0.4.0-M2",
+          %%("scalamockScalatest") % Test
       )
     )
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -33,6 +33,7 @@ object ProjectPlugin extends AutoPlugin {
       val circe: String              = "0.10.1"
       val frees: String              = "0.8.2"
       val fs2: String                = "1.0.0"
+      val fs2Grpc: String            = "0.4.0-M2"
       val jodaTime: String           = "2.10.1"
       val grpc: String               = "1.16.1"
       val log4s: String              = "1.6.1"
@@ -67,9 +68,9 @@ object ProjectPlugin extends AutoPlugin {
         %%("pbdirect", V.pbdirect),
         %%("avro4s", V.avro4s),
         %%("log4s", V.log4s),
+        "org.lyranthe.fs2-grpc"  %% "java-runtime" % V.fs2Grpc,
         "org.scala-lang"         % "scala-compiler" % scalaVersion.value,
-        "org.lyranthe.fs2-grpc" %% "java-runtime" % "0.4.0-M2",
-          %%("scalamockScalatest") % Test
+        %%("scalamockScalatest") % Test
       )
     )
 


### PR DESCRIPTION
`fs2-grpc` doesn't have support for compression at the server level.  A PR was submitted for addressing that: https://github.com/fiadliel/fs2-grpc/pull/42.

The fs2 support is still experimental so, IMO we're fine. 