### PR TITLE
Referential Transparency for RPC client

### DIFF
--- a/benchmarks/shared/src/main/scala/AvroWithSchemaBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/AvroWithSchemaBenchmark.scala
@@ -18,7 +18,7 @@ package mu.rpc.benchmarks
 
 import java.util.concurrent.TimeUnit
 
-import cats.effect.IO
+import cats.effect.{IO, Resource}
 import cats.syntax.functor._
 import mu.rpc.benchmarks.shared.Utils._
 import mu.rpc.benchmarks.shared.protocols.PersonServiceAvroWithSchema
@@ -36,30 +36,30 @@ class AvroWithSchemaBenchmark extends Runtime {
 
   implicit val handler: AvroWithSchemaHandler[IO] = new AvroWithSchemaHandler[IO]
   val sc: ServerChannel                           = ServerChannel(PersonServiceAvroWithSchema.bindService[IO])
-  val client: PersonServiceAvroWithSchema.Client[IO] =
-    PersonServiceAvroWithSchema.clientFromChannel[IO](sc.channel)
+  val clientIO: Resource[IO, PersonServiceAvroWithSchema.Client[IO]] =
+    PersonServiceAvroWithSchema.clientFromChannel[IO](IO(sc.channel))
 
   @TearDown
   def shutdown(): Unit = IO(sc.shutdown()).void.unsafeRunSync()
 
   @Benchmark
-  def listPersons: PersonList = client.listPersons(Empty).unsafeRunTimed(defaultTimeOut).get
+  def listPersons: PersonList = clientIO.use(_.listPersons(Empty)).unsafeRunTimed(defaultTimeOut).get
 
   @Benchmark
-  def getPerson: Person = client.getPerson(PersonId("1")).unsafeRunTimed(defaultTimeOut).get
+  def getPerson: Person = clientIO.use(_.getPerson(PersonId("1"))).unsafeRunTimed(defaultTimeOut).get
 
   @Benchmark
   def getPersonLinks: PersonLinkList =
-    client.getPersonLinks(PersonId("1")).unsafeRunTimed(defaultTimeOut).get
+    clientIO.use(_.getPersonLinks(PersonId("1"))).unsafeRunTimed(defaultTimeOut).get
 
   @Benchmark
   def createPerson: Person =
-    client.createPerson(person).unsafeRunTimed(defaultTimeOut).get
+    clientIO.use(_.createPerson(person)).unsafeRunTimed(defaultTimeOut).get
 
   @Benchmark
   def programComposition: PersonAggregation = {
 
-    def clientProgram: IO[PersonAggregation] = {
+    def clientProgram: IO[PersonAggregation] = clientIO.use { client =>
       for {
         personList <- client.listPersons(Empty)
         p1         <- client.getPerson(PersonId("1"))

--- a/benchmarks/shared/src/main/scala/ProtoBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/ProtoBenchmark.scala
@@ -16,7 +16,7 @@
 
 package mu.rpc.benchmarks
 
-import cats.effect.IO
+import cats.effect.{IO, Resource}
 import cats.syntax.functor._
 import mu.rpc.protocol.Empty
 import java.util.concurrent.TimeUnit
@@ -36,29 +36,29 @@ class ProtoBenchmark extends Runtime {
 
   implicit val handler: ProtoHandler[IO] = new ProtoHandler[IO]
   val sc: ServerChannel                  = ServerChannel(PersonServicePB.bindService[IO])
-  val client: PersonServicePB.Client[IO] = PersonServicePB.clientFromChannel[IO](sc.channel)
+  val clientIO: Resource[IO, PersonServicePB.Client[IO]] = PersonServicePB.clientFromChannel[IO](IO(sc.channel))
 
   @TearDown
   def shutdown(): Unit = IO(sc.shutdown()).void.unsafeRunSync()
 
   @Benchmark
-  def listPersons: PersonList = client.listPersons(Empty).unsafeRunTimed(defaultTimeOut).get
+  def listPersons: PersonList = clientIO.use(_.listPersons(Empty)).unsafeRunTimed(defaultTimeOut).get
 
   @Benchmark
-  def getPerson: Person = client.getPerson(PersonId("1")).unsafeRunTimed(defaultTimeOut).get
+  def getPerson: Person = clientIO.use(_.getPerson(PersonId("1"))).unsafeRunTimed(defaultTimeOut).get
 
   @Benchmark
   def getPersonLinks: PersonLinkList =
-    client.getPersonLinks(PersonId("1")).unsafeRunTimed(defaultTimeOut).get
+    clientIO.use(_.getPersonLinks(PersonId("1"))).unsafeRunTimed(defaultTimeOut).get
 
   @Benchmark
   def createPerson: Person =
-    client.createPerson(person).unsafeRunTimed(defaultTimeOut).get
+    clientIO.use(_.createPerson(person)).unsafeRunTimed(defaultTimeOut).get
 
   @Benchmark
   def programComposition: PersonAggregation = {
 
-    def clientProgram: IO[PersonAggregation] = {
+    def clientProgram: IO[PersonAggregation] = clientIO.use { client =>
       for {
         personList <- client.listPersons(Empty)
         p1         <- client.getPerson(PersonId("1"))

--- a/docs/src/main/tut/core-concepts.md
+++ b/docs/src/main/tut/core-concepts.md
@@ -232,7 +232,7 @@ trait CommonRuntime {
 ```
 
 ```tut:silent
-import cats.effect.IO
+import cats.effect.{IO, Resource}
 import mu.rpc._
 import mu.rpc.config._
 import mu.rpc.client.config._
@@ -244,7 +244,7 @@ trait ChannelImplicits extends CommonRuntime {
   val channelFor: ChannelFor =
     ConfigForAddress[IO]("rpc.host", "rpc.port").unsafeRunSync
 
-  implicit val serviceClient: Greeter.Client[IO] =
+  implicit val serviceClient: Resource[IO, Greeter.Client[IO]] =
     Greeter.client[IO](channelFor, options = CallOptions.DEFAULT.withCompression("gzip"))
 }
 

--- a/docs/src/main/tut/metrics-reporting.md
+++ b/docs/src/main/tut/metrics-reporting.md
@@ -89,7 +89,7 @@ object InterceptingServerCalls extends CommonRuntime {
 In this case, in order to intercept the client calls we need additional configuration settings (by using `AddInterceptor`):
 
 ```tut:silent
-import cats.effect.IO
+import cats.effect.{IO, Resource}
 import mu.rpc._
 import mu.rpc.config._
 import mu.rpc.client._
@@ -104,7 +104,7 @@ object InterceptingClientCalls extends CommonRuntime {
   val channelFor: ChannelFor =
     ConfigForAddress[IO]("rpc.host", "rpc.port").unsafeRunSync
 
-  implicit val serviceClient: Greeter.Client[IO] =
+  implicit val serviceClient: Resource[IO, Greeter.Client[IO]] =
     Greeter.client[IO](
       channelFor = channelFor,
       channelConfigList = List(

--- a/docs/src/main/tut/ssl-tls.md
+++ b/docs/src/main/tut/ssl-tls.md
@@ -79,7 +79,7 @@ class ServiceHandler[F[_]: Applicative] extends Greeter[F] {
 import java.io.File
 import java.security.cert.X509Certificate
 
-import cats.effect.IO
+import cats.effect.{IO, Resource}
 import mu.rpc.server.netty.SetSslContext
 import mu.rpc.server.{AddService, GrpcConfig, GrpcServer}
 import io.grpc.internal.testing.TestUtils
@@ -129,6 +129,7 @@ object implicits extends Runtime
 Lastly, as we did before with the server side, let's see what happens on the client side.
 
 ```tut:silent
+import cats.syntax.either._
 import mu.rpc.ChannelForAddress
 import mu.rpc.client.OverrideAuthority
 import mu.rpc.client.netty.{
@@ -168,15 +169,15 @@ object MainApp extends CommonRuntime {
   val channelInterpreter: NettyChannelInterpreter = new NettyChannelInterpreter(
     ChannelForAddress("localhost", 8080),
     List(
-      OverrideAuthority(TestUtils.TEST_SERVER_HOST),
-      NettyUsePlaintext(),
-      NettyNegotiationType(NegotiationType.TLS),
-      NettySslContext(clientSslContext)
+      OverrideAuthority(TestUtils.TEST_SERVER_HOST).asLeft,
+      NettyUsePlaintext().asRight,
+      NettyNegotiationType(NegotiationType.TLS).asRight,
+      NettySslContext(clientSslContext).asRight
     )
   )
 
-  val muRPCServiceClient: Greeter.Client[IO] =
-    Greeter.clientFromChannel[IO](channelInterpreter.build)
+  val muRPCServiceClient: Resource[IO, Greeter.Client[IO]] =
+    Greeter.clientFromChannel[IO](IO(channelInterpreter.build))
 
 }
 ```

--- a/docs/src/main/tut/ssl-tls.md
+++ b/docs/src/main/tut/ssl-tls.md
@@ -168,11 +168,11 @@ object MainApp extends CommonRuntime {
 
   val channelInterpreter: NettyChannelInterpreter = new NettyChannelInterpreter(
     ChannelForAddress("localhost", 8080),
+    List(OverrideAuthority(TestUtils.TEST_SERVER_HOST)),
     List(
-      OverrideAuthority(TestUtils.TEST_SERVER_HOST).asLeft,
-      NettyUsePlaintext().asRight,
-      NettyNegotiationType(NegotiationType.TLS).asRight,
-      NettySslContext(clientSslContext).asRight
+      NettyUsePlaintext(),
+      NettyNegotiationType(NegotiationType.TLS),
+      NettySslContext(clientSslContext)
     )
   )
 

--- a/modules/client-netty/src/main/scala/NettyChannelConfig.scala
+++ b/modules/client-netty/src/main/scala/NettyChannelConfig.scala
@@ -24,7 +24,7 @@ import io.grpc.netty.NegotiationType
 import io.netty.channel.{Channel, ChannelOption, EventLoopGroup}
 import io.netty.handler.ssl.SslContext
 
-sealed trait NettyChannelConfig                                         extends ManagedChannelConfig
+sealed trait NettyChannelConfig                                         extends Product with Serializable
 final case class NettyChannelType(channelType: Class[_ <: Channel])     extends NettyChannelConfig
 final case class NettyWithOption[T](option: ChannelOption[T], value: T) extends NettyChannelConfig
 final case class NettyNegotiationType(`type`: NegotiationType)          extends NettyChannelConfig

--- a/modules/client-netty/src/main/scala/netty.scala
+++ b/modules/client-netty/src/main/scala/netty.scala
@@ -36,12 +36,12 @@ package object netty {
           throw new IllegalArgumentException(s"ManagedChannel not supported for $e")
       }
 
-      nettyConfigList
-        .foldLeft(
-          configList
-            .foldLeft(builder)((acc, cfg) => configureChannel(acc, cfg)))((acc, cfg) =>
-          configureNettyChannel(acc)(cfg))
-        .build()
+      val baseBuilder: NettyChannelBuilder => NettyChannelBuilder =
+        configList.foldLeft(_)((acc, cfg) => configureChannel(acc, cfg))
+      val nettyBuilder: NettyChannelBuilder => NettyChannelBuilder =
+        nettyConfigList.foldLeft(_)((acc, cfg) => configureNettyChannel(acc)(cfg))
+
+      (baseBuilder andThen nettyBuilder)(builder).build()
     }
   }
 

--- a/modules/client-netty/src/test/scala/ManagedChannelInterpreterNettyTests.scala
+++ b/modules/client-netty/src/test/scala/ManagedChannelInterpreterNettyTests.scala
@@ -18,8 +18,6 @@ package mu.rpc
 package client
 package netty
 
-import cats.syntax.either._
-
 import java.net.InetSocketAddress
 import java.util.concurrent.TimeUnit
 
@@ -41,10 +39,9 @@ class ManagedChannelInterpreterNettyTests extends ManagedChannelInterpreterTests
 
       val channelFor: ChannelFor = ChannelForSocketAddress(new InetSocketAddress(SC.host, 45455))
 
-      val channelConfigList =
-        List(UsePlaintext().asLeft[NettyChannelConfig])
+      val channelConfigList = List(UsePlaintext())
 
-      val interpreter = new NettyChannelInterpreter(channelFor, channelConfigList)
+      val interpreter = new NettyChannelInterpreter(channelFor, channelConfigList, Nil)
 
       val mc: ManagedChannel = interpreter.build
 
@@ -57,7 +54,7 @@ class ManagedChannelInterpreterNettyTests extends ManagedChannelInterpreterTests
 
       val channelFor: ChannelFor = ChannelForTarget(SC.host)
 
-      val interpreter = new NettyChannelInterpreter(channelFor, Nil)
+      val interpreter = new NettyChannelInterpreter(channelFor, Nil, Nil)
 
       val mc: ManagedChannel = interpreter.build
 
@@ -70,25 +67,23 @@ class ManagedChannelInterpreterNettyTests extends ManagedChannelInterpreterTests
 
       val channelFor: ChannelFor = ChannelForAddress(SC.host, SC.port)
 
-      val channelConfigList: List[Either[ManagedChannelConfig, NettyChannelConfig]] = managedChannelConfigAllList
-        .map(_.asLeft[NettyChannelConfig]) ++ List(
-        NettyChannelType((new LocalChannel).getClass).asRight[ManagedChannelConfig],
-        NettyWithOption[Boolean](ChannelOption.valueOf("ALLOCATOR"), true)
-          .asRight[ManagedChannelConfig],
-        NettyNegotiationType(NegotiationType.PLAINTEXT).asRight[ManagedChannelConfig],
-        NettyEventLoopGroup(new NioEventLoopGroup(0)).asRight[ManagedChannelConfig],
-        NettySslContext(GrpcSslContexts.forClient.build).asRight[ManagedChannelConfig],
-        NettyFlowControlWindow(NettyChannelBuilder.DEFAULT_FLOW_CONTROL_WINDOW)
-          .asRight[ManagedChannelConfig],
-        NettyMaxHeaderListSize(GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE).asRight[ManagedChannelConfig],
-        NettyUsePlaintext().asRight[ManagedChannelConfig],
-        NettyUseTransportSecurity.asRight[ManagedChannelConfig],
-        NettyKeepAliveTime(1, TimeUnit.MINUTES).asRight[ManagedChannelConfig],
-        NettyKeepAliveTimeout(1, TimeUnit.MINUTES).asRight[ManagedChannelConfig],
-        NettyKeepAliveWithoutCalls(false).asRight[ManagedChannelConfig]
+      val nettyChannelConfigList: List[NettyChannelConfig] = List(
+        NettyChannelType((new LocalChannel).getClass),
+        NettyWithOption[Boolean](ChannelOption.valueOf("ALLOCATOR"), true),
+        NettyNegotiationType(NegotiationType.PLAINTEXT),
+        NettyEventLoopGroup(new NioEventLoopGroup(0)),
+        NettySslContext(GrpcSslContexts.forClient.build),
+        NettyFlowControlWindow(NettyChannelBuilder.DEFAULT_FLOW_CONTROL_WINDOW),
+        NettyMaxHeaderListSize(GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE),
+        NettyUsePlaintext(),
+        NettyUseTransportSecurity,
+        NettyKeepAliveTime(1, TimeUnit.MINUTES),
+        NettyKeepAliveTimeout(1, TimeUnit.MINUTES),
+        NettyKeepAliveWithoutCalls(false)
       )
 
-      val interpreter = new NettyChannelInterpreter(channelFor, channelConfigList)
+      val interpreter =
+        new NettyChannelInterpreter(channelFor, managedChannelConfigAllList, nettyChannelConfigList)
 
       val mc: ManagedChannel = interpreter.build
 
@@ -101,7 +96,7 @@ class ManagedChannelInterpreterNettyTests extends ManagedChannelInterpreterTests
 
       val channelFor: ChannelFor = ChannelForPort(SC.port)
 
-      val interpreter = new NettyChannelInterpreter(channelFor, Nil)
+      val interpreter = new NettyChannelInterpreter(channelFor, Nil, Nil)
 
       an[IllegalArgumentException] shouldBe thrownBy(interpreter.build)
     }

--- a/modules/client-netty/src/test/scala/ManagedChannelInterpreterNettyTests.scala
+++ b/modules/client-netty/src/test/scala/ManagedChannelInterpreterNettyTests.scala
@@ -85,7 +85,7 @@ class ManagedChannelInterpreterNettyTests extends ManagedChannelInterpreterTests
         NettyUseTransportSecurity.asRight[ManagedChannelConfig],
         NettyKeepAliveTime(1, TimeUnit.MINUTES).asRight[ManagedChannelConfig],
         NettyKeepAliveTimeout(1, TimeUnit.MINUTES).asRight[ManagedChannelConfig],
-        NettyKeepAliveWithoutCalls(false).asRight[ManagedChannelConfig],
+        NettyKeepAliveWithoutCalls(false).asRight[ManagedChannelConfig]
       )
 
       val interpreter = new NettyChannelInterpreter(channelFor, channelConfigList)

--- a/modules/client-netty/src/test/scala/ManagedChannelInterpreterNettyTests.scala
+++ b/modules/client-netty/src/test/scala/ManagedChannelInterpreterNettyTests.scala
@@ -18,6 +18,8 @@ package mu.rpc
 package client
 package netty
 
+import cats.syntax.either._
+
 import java.net.InetSocketAddress
 import java.util.concurrent.TimeUnit
 
@@ -39,7 +41,8 @@ class ManagedChannelInterpreterNettyTests extends ManagedChannelInterpreterTests
 
       val channelFor: ChannelFor = ChannelForSocketAddress(new InetSocketAddress(SC.host, 45455))
 
-      val channelConfigList: List[ManagedChannelConfig] = List(UsePlaintext())
+      val channelConfigList =
+        List(UsePlaintext().asLeft[NettyChannelConfig])
 
       val interpreter = new NettyChannelInterpreter(channelFor, channelConfigList)
 
@@ -67,19 +70,22 @@ class ManagedChannelInterpreterNettyTests extends ManagedChannelInterpreterTests
 
       val channelFor: ChannelFor = ChannelForAddress(SC.host, SC.port)
 
-      val channelConfigList: List[ManagedChannelConfig] = managedChannelConfigAllList ++ List(
-        NettyChannelType((new LocalChannel).getClass),
-        NettyWithOption[Boolean](ChannelOption.valueOf("ALLOCATOR"), true),
-        NettyNegotiationType(NegotiationType.PLAINTEXT),
-        NettyEventLoopGroup(new NioEventLoopGroup(0)),
-        NettySslContext(GrpcSslContexts.forClient.build),
-        NettyFlowControlWindow(NettyChannelBuilder.DEFAULT_FLOW_CONTROL_WINDOW),
-        NettyMaxHeaderListSize(GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE),
-        NettyUsePlaintext(),
-        NettyUseTransportSecurity,
-        NettyKeepAliveTime(1, TimeUnit.MINUTES),
-        NettyKeepAliveTimeout(1, TimeUnit.MINUTES),
-        NettyKeepAliveWithoutCalls(false)
+      val channelConfigList: List[Either[ManagedChannelConfig, NettyChannelConfig]] = managedChannelConfigAllList
+        .map(_.asLeft[NettyChannelConfig]) ++ List(
+        NettyChannelType((new LocalChannel).getClass).asRight[ManagedChannelConfig],
+        NettyWithOption[Boolean](ChannelOption.valueOf("ALLOCATOR"), true)
+          .asRight[ManagedChannelConfig],
+        NettyNegotiationType(NegotiationType.PLAINTEXT).asRight[ManagedChannelConfig],
+        NettyEventLoopGroup(new NioEventLoopGroup(0)).asRight[ManagedChannelConfig],
+        NettySslContext(GrpcSslContexts.forClient.build).asRight[ManagedChannelConfig],
+        NettyFlowControlWindow(NettyChannelBuilder.DEFAULT_FLOW_CONTROL_WINDOW)
+          .asRight[ManagedChannelConfig],
+        NettyMaxHeaderListSize(GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE).asRight[ManagedChannelConfig],
+        NettyUsePlaintext().asRight[ManagedChannelConfig],
+        NettyUseTransportSecurity.asRight[ManagedChannelConfig],
+        NettyKeepAliveTime(1, TimeUnit.MINUTES).asRight[ManagedChannelConfig],
+        NettyKeepAliveTimeout(1, TimeUnit.MINUTES).asRight[ManagedChannelConfig],
+        NettyKeepAliveWithoutCalls(false).asRight[ManagedChannelConfig],
       )
 
       val interpreter = new NettyChannelInterpreter(channelFor, channelConfigList)
@@ -89,18 +95,6 @@ class ManagedChannelInterpreterNettyTests extends ManagedChannelInterpreterTests
       mc shouldBe a[ManagedChannel]
 
       mc.shutdownNow()
-    }
-
-    "throw an exception when configuration is not recognized" in {
-
-      val channelFor: ChannelFor = ChannelForAddress(SC.host, SC.port)
-
-      case object Unexpected extends ManagedChannelConfig
-      val channelConfigList: List[ManagedChannelConfig] = List(Unexpected)
-
-      val interpreter = new NettyChannelInterpreter(channelFor, channelConfigList)
-
-      a[MatchError] shouldBe thrownBy(interpreter.build)
     }
 
     "throw an exception when ChannelFor is not recognized" in {

--- a/modules/client/src/main/scala/ManagedChannelConfig.scala
+++ b/modules/client/src/main/scala/ManagedChannelConfig.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.{Executor, TimeUnit}
 
 import io.grpc._
 
-trait ManagedChannelConfig                       extends Product with Serializable
+sealed trait ManagedChannelConfig                extends Product with Serializable
 case object DirectExecutor                       extends ManagedChannelConfig
 final case class SetExecutor(executor: Executor) extends ManagedChannelConfig
 final case class AddInterceptorList(interceptors: List[ClientInterceptor])

--- a/modules/client/src/main/scala/package.scala
+++ b/modules/client/src/main/scala/package.scala
@@ -16,6 +16,9 @@
 
 package mu.rpc
 
+import cats.effect.Sync
+import cats.syntax.flatMap._
+import cats.syntax.functor._
 import cats.data.Kleisli
 import cats.~>
 
@@ -24,49 +27,50 @@ import io.grpc._
 
 package object client {
 
-  type ManagedChannelOps[F[_], A] = Kleisli[F, ManagedChannel, A]
+  type ManagedChannelOps[F[_], A] = Kleisli[F, F[ManagedChannel], A]
 
   class ManagedChannelInterpreter[F[_]](
       initConfig: ChannelFor,
-      configList: List[ManagedChannelConfig])
-      extends (Kleisli[F, ManagedChannel, ?] ~> F) {
+      configList: List[ManagedChannelConfig])(implicit F: Sync[F]) {
 
     def build[T <: ManagedChannelBuilder[T]](
         initConfig: ChannelFor,
-        configList: List[ManagedChannelConfig]): ManagedChannel = {
-      val builder: T = initConfig match {
+        configList: List[ManagedChannelConfig]): F[ManagedChannel] = {
+
+      val builder: F[T] = initConfig match {
         case ChannelForAddress(name, port) =>
-          ManagedChannelBuilder.forAddress(name, port).asInstanceOf[T]
-        case ChannelForTarget(target) => ManagedChannelBuilder.forTarget(target).asInstanceOf[T]
+          F.delay(ManagedChannelBuilder.forAddress(name, port).asInstanceOf[T])
+        case ChannelForTarget(target) =>
+          F.delay(ManagedChannelBuilder.forTarget(target).asInstanceOf[T])
         case e =>
-          throw new IllegalArgumentException(s"ManagedChannel not supported for $e")
+          F.raiseError(new IllegalArgumentException(s"ManagedChannel not supported for $e"))
       }
 
-      configList
-        .foldLeft(builder) { (acc, cfg) =>
-          ManagedChannelB(acc)(cfg)
-        }
-        .build()
+      for {
+        b          <- builder
+        configured <- F.delay(configList.foldLeft(b)(configureChannel))
+        built      <- F.delay(configured.build())
+      } yield built
     }
 
-    override def apply[A](fa: Kleisli[F, ManagedChannel, A]): F[A] =
+    def apply[A](fa: ManagedChannelOps[F, A]): F[A] =
       fa(build(initConfig, configList))
   }
 
-  def ManagedChannelB[T <: ManagedChannelBuilder[T]](
-      mcb: T): PartialFunction[ManagedChannelConfig, T] = {
-    case DirectExecutor                    => mcb.directExecutor()
-    case SetExecutor(executor)             => mcb.executor(executor)
-    case AddInterceptorList(interceptors)  => mcb.intercept(interceptors.asJava)
-    case AddInterceptor(interceptors @ _*) => mcb.intercept(interceptors: _*)
-    case UserAgent(userAgent)              => mcb.userAgent(userAgent)
-    case OverrideAuthority(authority)      => mcb.overrideAuthority(authority)
-    case UsePlaintext()                    => mcb.usePlaintext()
-    case NameResolverFactory(rf)           => mcb.nameResolverFactory(rf)
-    case LoadBalancerFactory(lbf)          => mcb.loadBalancerFactory(lbf)
-    case SetDecompressorRegistry(registry) => mcb.decompressorRegistry(registry)
-    case SetCompressorRegistry(registry)   => mcb.compressorRegistry(registry)
-    case SetIdleTimeout(value, unit)       => mcb.idleTimeout(value, unit)
-    case SetMaxInboundMessageSize(max)     => mcb.maxInboundMessageSize(max)
-  }
+  def configureChannel[T <: ManagedChannelBuilder[T]](mcb: T, conf: ManagedChannelConfig): T =
+    conf match {
+      case DirectExecutor                    => mcb.directExecutor()
+      case SetExecutor(executor)             => mcb.executor(executor)
+      case AddInterceptorList(interceptors)  => mcb.intercept(interceptors.asJava)
+      case AddInterceptor(interceptors @ _*) => mcb.intercept(interceptors: _*)
+      case UserAgent(userAgent)              => mcb.userAgent(userAgent)
+      case OverrideAuthority(authority)      => mcb.overrideAuthority(authority)
+      case UsePlaintext()                    => mcb.usePlaintext()
+      case NameResolverFactory(rf)           => mcb.nameResolverFactory(rf)
+      case LoadBalancerFactory(lbf)          => mcb.loadBalancerFactory(lbf)
+      case SetDecompressorRegistry(registry) => mcb.decompressorRegistry(registry)
+      case SetCompressorRegistry(registry)   => mcb.compressorRegistry(registry)
+      case SetIdleTimeout(value, unit)       => mcb.idleTimeout(value, unit)
+      case SetMaxInboundMessageSize(max)     => mcb.maxInboundMessageSize(max)
+    }
 }

--- a/modules/client/src/test/scala/ManagedChannelInterpreterTests.scala
+++ b/modules/client/src/test/scala/ManagedChannelInterpreterTests.scala
@@ -37,8 +37,7 @@ abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
       val managedChannelInterpreter =
         new ManagedChannelInterpreter[IO](channelFor, channelConfigList)
 
-      val mc: ManagedChannel =
-        managedChannelInterpreter.build(channelFor, channelConfigList).unsafeRunSync
+      val mc: ManagedChannel = managedChannelInterpreter.unsafeBuild(channelFor, channelConfigList)
 
       mc shouldBe a[ManagedChannel]
 
@@ -54,8 +53,7 @@ abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
       val managedChannelInterpreter =
         new ManagedChannelInterpreter[IO](channelFor, channelConfigList)
 
-      val mc: ManagedChannel =
-        managedChannelInterpreter.build(channelFor, channelConfigList).unsafeRunSync
+      val mc: ManagedChannel = managedChannelInterpreter.unsafeBuild(channelFor, channelConfigList)
 
       mc shouldBe a[ManagedChannel]
 
@@ -86,8 +84,7 @@ abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
       val managedChannelInterpreter =
         new ManagedChannelInterpreter[IO](channelFor, channelConfigList)
 
-      val mc: ManagedChannel =
-        managedChannelInterpreter.build(channelFor, channelConfigList).unsafeRunSync
+      val mc: ManagedChannel = managedChannelInterpreter.unsafeBuild(channelFor, channelConfigList)
 
       mc shouldBe a[ManagedChannel]
 

--- a/modules/client/src/test/scala/ManagedChannelInterpreterTests.scala
+++ b/modules/client/src/test/scala/ManagedChannelInterpreterTests.scala
@@ -17,12 +17,10 @@
 package mu.rpc
 package client
 
+import cats.effect.IO
 import cats.data.Kleisli
 import mu.rpc.common.SC
 import io.grpc.ManagedChannel
-
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, Future}
 
 abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
 
@@ -37,11 +35,12 @@ abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
       val channelConfigList: List[ManagedChannelConfig] = List(UsePlaintext())
 
       val managedChannelInterpreter =
-        new ManagedChannelInterpreter[Future](channelFor, channelConfigList)
+        new ManagedChannelInterpreter[IO](channelFor, channelConfigList)
 
-      val mc: ManagedChannel = managedChannelInterpreter.build(channelFor, channelConfigList)
+      val mc: ManagedChannel =
+        managedChannelInterpreter.build(channelFor, channelConfigList).unsafeRunSync
 
-      mc shouldBe an[ManagedChannel]
+      mc shouldBe a[ManagedChannel]
 
       mc.shutdownNow()
     }
@@ -53,9 +52,10 @@ abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
       val channelConfigList: List[ManagedChannelConfig] = List(UsePlaintext())
 
       val managedChannelInterpreter =
-        new ManagedChannelInterpreter[Future](channelFor, channelConfigList)
+        new ManagedChannelInterpreter[IO](channelFor, channelConfigList)
 
-      val mc: ManagedChannel = managedChannelInterpreter.build(channelFor, channelConfigList)
+      val mc: ManagedChannel =
+        managedChannelInterpreter.build(channelFor, channelConfigList).unsafeRunSync
 
       mc shouldBe a[ManagedChannel]
 
@@ -69,15 +69,12 @@ abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
       val channelConfigList: List[ManagedChannelConfig] = List(UsePlaintext())
 
       val managedChannelInterpreter =
-        new ManagedChannelInterpreter[Future](channelFor, channelConfigList)
+        new ManagedChannelInterpreter[IO](channelFor, channelConfigList)
 
-      val kleisli: ManagedChannelOps[Future, String] =
-        Kleisli[Future, ManagedChannel, String]((mc: ManagedChannel) => {
-          mc.shutdownNow()
-          Future.successful(foo)
-        })
+      val kleisli: ManagedChannelOps[IO, String] =
+        Kleisli.liftF(IO(foo))
 
-      Await.result(managedChannelInterpreter[String](kleisli), Duration.Inf) shouldBe foo
+      managedChannelInterpreter[String](kleisli).unsafeRunSync shouldBe foo
     }
 
     "build a io.grpc.ManagedChannel based on any configuration combination" in {
@@ -87,27 +84,14 @@ abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
       val channelConfigList: List[ManagedChannelConfig] = managedChannelConfigAllList
 
       val managedChannelInterpreter =
-        new ManagedChannelInterpreter[Future](channelFor, channelConfigList)
+        new ManagedChannelInterpreter[IO](channelFor, channelConfigList)
 
-      val mc: ManagedChannel = managedChannelInterpreter.build(channelFor, channelConfigList)
+      val mc: ManagedChannel =
+        managedChannelInterpreter.build(channelFor, channelConfigList).unsafeRunSync
 
       mc shouldBe a[ManagedChannel]
 
       mc.shutdownNow()
-    }
-
-    "throw an exception when configuration is not recognized" in {
-
-      val channelFor: ChannelFor = ChannelForAddress(SC.host, SC.port)
-
-      case object Unexpected extends ManagedChannelConfig
-      val channelConfigList: List[ManagedChannelConfig] = List(Unexpected)
-
-      val managedChannelInterpreter =
-        new ManagedChannelInterpreter[Future](channelFor, channelConfigList)
-
-      a[MatchError] shouldBe thrownBy(
-        managedChannelInterpreter.build(channelFor, channelConfigList))
     }
 
     "throw an exception when ChannelFor is not recognized" in {
@@ -115,10 +99,10 @@ abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
       val channelFor: ChannelFor = ChannelForPort(SC.port)
 
       val managedChannelInterpreter =
-        new ManagedChannelInterpreter[Future](channelFor, Nil)
+        new ManagedChannelInterpreter[IO](channelFor, Nil)
 
       an[IllegalArgumentException] shouldBe thrownBy(
-        managedChannelInterpreter.build(channelFor, Nil))
+        managedChannelInterpreter.build(channelFor, Nil).unsafeRunSync)
     }
   }
 }

--- a/modules/examples/routeguide/client/src/main/scala-io/implicitsio.scala
+++ b/modules/examples/routeguide/client/src/main/scala-io/implicitsio.scala
@@ -16,7 +16,7 @@
 
 package example.routeguide.client.io
 
-import cats.effect.IO
+import cats.effect.{IO, Resource}
 import example.routeguide.client.handlers.RouteGuideClientHandler
 import example.routeguide.protocol.Protocols._
 import example.routeguide.runtime._
@@ -24,7 +24,7 @@ import example.routeguide.client.runtime._
 
 trait ClientIOImplicits extends RouteGuide with ClientConf {
 
-  implicit val routeGuideServiceClient: IO[RouteGuideService.Client[IO]] =
+  implicit val routeGuideServiceClient: Resource[IO, RouteGuideService.Client[IO]] =
     RouteGuideService.client[IO](channelFor)
 
   implicit val routeGuideClientHandler: RouteGuideClientHandler[IO] =

--- a/modules/examples/routeguide/client/src/main/scala-io/implicitsio.scala
+++ b/modules/examples/routeguide/client/src/main/scala-io/implicitsio.scala
@@ -24,7 +24,7 @@ import example.routeguide.client.runtime._
 
 trait ClientIOImplicits extends RouteGuide with ClientConf {
 
-  implicit val routeGuideServiceClient: RouteGuideService.Client[IO] =
+  implicit val routeGuideServiceClient: IO[RouteGuideService.Client[IO]] =
     RouteGuideService.client[IO](channelFor)
 
   implicit val routeGuideClientHandler: RouteGuideClientHandler[IO] =

--- a/modules/examples/routeguide/client/src/main/scala-task/implicitstask.scala
+++ b/modules/examples/routeguide/client/src/main/scala-task/implicitstask.scala
@@ -24,7 +24,7 @@ import monix.eval.Task
 
 trait ClientTaskImplicits extends RouteGuide with ClientConf {
 
-  implicit val routeGuideServiceClient: RouteGuideService.Client[Task] =
+  implicit val routeGuideServiceClient: Task[RouteGuideService.Client[Task]] =
     RouteGuideService.client[Task](channelFor)
 
   implicit val routeGuideClientHandler: RouteGuideClientHandler[Task] =

--- a/modules/examples/routeguide/client/src/main/scala-task/implicitstask.scala
+++ b/modules/examples/routeguide/client/src/main/scala-task/implicitstask.scala
@@ -16,6 +16,7 @@
 
 package example.routeguide.client.task
 
+import cats.effect.Resource
 import example.routeguide.client.handlers.RouteGuideClientHandler
 import example.routeguide.protocol.Protocols._
 import example.routeguide.runtime._
@@ -24,7 +25,7 @@ import monix.eval.Task
 
 trait ClientTaskImplicits extends RouteGuide with ClientConf {
 
-  implicit val routeGuideServiceClient: Task[RouteGuideService.Client[Task]] =
+  implicit val routeGuideServiceClient: Resource[Task, RouteGuideService.Client[Task]] =
     RouteGuideService.client[Task](channelFor)
 
   implicit val routeGuideClientHandler: RouteGuideClientHandler[Task] =

--- a/modules/examples/routeguide/client/src/main/scala/handlers/RouteGuideClientHandler.scala
+++ b/modules/examples/routeguide/client/src/main/scala/handlers/RouteGuideClientHandler.scala
@@ -17,7 +17,7 @@
 package example.routeguide.client.handlers
 
 import cats._
-import cats.effect.{Async, ConcurrentEffect, Effect}
+import cats.effect.{Async, ConcurrentEffect, Effect, Resource}
 import cats.implicits._
 import example.routeguide.client.RouteGuideClient
 import io.grpc.{Status, StatusRuntimeException}
@@ -30,7 +30,7 @@ import example.routeguide.common.Utils._
 import scala.concurrent.duration._
 
 class RouteGuideClientHandler[F[_]: ConcurrentEffect](
-    implicit client: RouteGuideService.Client[F],
+    implicit client: Resource[F, RouteGuideService.Client[F]],
     E: Effect[Task])
     extends RouteGuideClient[F] {
 
@@ -39,7 +39,7 @@ class RouteGuideClientHandler[F[_]: ConcurrentEffect](
   override def getFeature(lat: Int, lon: Int): F[Unit] =
     Async[F].delay(logger.info(s"*** GetFeature: lat=$lat lon=$lon")) *>
       client
-        .getFeature(Point(lat, lon))
+        .use(_.getFeature(Point(lat, lon)))
         .map { feature: Feature =>
           if (feature.valid)
             logger.info(s"Found feature called '${feature.name}' at ${feature.location.pretty}")
@@ -52,26 +52,27 @@ class RouteGuideClientHandler[F[_]: ConcurrentEffect](
               Throwable].raiseError(e)
         }
 
-  override def listFeatures(lowLat: Int, lowLon: Int, hiLat: Int, hiLon: Int): F[Unit] = {
-    logger.info(s"*** ListFeatures: lowLat=$lowLat lowLon=$lowLon hiLat=$hiLat hiLon=$hiLon")
-    client
-      .listFeatures(
-        Rectangle(
-          lo = Point(lowLat, lowLon),
-          hi = Point(hiLat, hiLon)
-        ))
-      .zipWithIndex
-      .map {
-        case (feature, i) =>
-          logger.info(s"Result #$i: $feature")
-      }
-      .onErrorHandle {
-        case e: StatusRuntimeException =>
-          logger.warn(s"RPC failed: ${e.getStatus} $e")
-          throw e
-      }
-      .completedL
-  }.toAsync[F]
+  override def listFeatures(lowLat: Int, lowLon: Int, hiLat: Int, hiLon: Int): F[Unit] =
+    Async[F].delay(
+      logger.info(s"*** ListFeatures: lowLat=$lowLat lowLon=$lowLon hiLat=$hiLat hiLon=$hiLon")) *>
+      client
+        .use(
+          _.listFeatures(
+            Rectangle(
+              lo = Point(lowLat, lowLon),
+              hi = Point(hiLat, hiLon)
+            )).zipWithIndex
+            .map {
+              case (feature, i) =>
+                logger.info(s"Result #$i: $feature")
+            }
+            .onErrorHandle {
+              case e: StatusRuntimeException =>
+                logger.warn(s"RPC failed: ${e.getStatus} $e")
+                throw e
+            }
+            .completedL
+            .toAsync[F])
 
   override def recordRoute(features: List[Feature], numPoints: Int): F[Unit] = {
     def takeN: List[Feature] = scala.util.Random.shuffle(features).take(numPoints)
@@ -79,10 +80,11 @@ class RouteGuideClientHandler[F[_]: ConcurrentEffect](
     val points = takeN.map(_.location)
     Async[F].delay(logger.info(s"*** RecordRoute. Points: ${points.map(_.pretty).mkString(";")}")) *>
       client
-        .recordRoute(
-          Observable
-            .fromIterable(points)
-            .delayOnNext(500.milliseconds))
+        .use(
+          _.recordRoute(
+            Observable
+              .fromIterable(points)
+              .delayOnNext(500.milliseconds)))
         .map { summary: RouteSummary =>
           logger.info(
             s"Finished trip with ${summary.point_count} points. Passed ${summary.feature_count} features. " +
@@ -94,35 +96,34 @@ class RouteGuideClientHandler[F[_]: ConcurrentEffect](
         }
   }
 
-  override def routeChat: F[Unit] = {
-    logger.info("*** RouteChat")
-    client
-      .routeChat(
-        Observable
-          .fromIterable(List(
-            RouteNote(message = "First message", location = Point(0, 0)),
-            RouteNote(message = "Second message", location = Point(0, 1)),
-            RouteNote(message = "Third message", location = Point(1, 0)),
-            RouteNote(message = "Fourth message", location = Point(1, 1))
-          ))
-          .delayOnNext(10.milliseconds)
-          .map { routeNote =>
-            logger.info(s"Sending message '${routeNote.message}' at " +
-              s"${routeNote.location.latitude}, ${routeNote.location.longitude}")
-            routeNote
-          }
-      )
-      .map { note: RouteNote =>
-        logger.info(
-          s"Got message '${note.message}' at " +
-            s"${note.location.latitude}, ${note.location.longitude}")
-      }
-      .onErrorHandle {
-        case e: Throwable =>
-          logger.warn(s"RouteChat Failed: ${Status.fromThrowable(e)} $e")
-          throw e
-      }
-      .completedL
-  }.toAsync[F]
+  override def routeChat: F[Unit] =
+    Async[F].delay(logger.info("*** RouteChat")) *>
+      client
+        .use(
+          _.routeChat(
+            Observable
+              .fromIterable(List(
+                RouteNote(message = "First message", location = Point(0, 0)),
+                RouteNote(message = "Second message", location = Point(0, 1)),
+                RouteNote(message = "Third message", location = Point(1, 0)),
+                RouteNote(message = "Fourth message", location = Point(1, 1))
+              ))
+              .delayOnNext(10.milliseconds)
+              .map { routeNote =>
+                logger.info(s"Sending message '${routeNote.message}' at " +
+                  s"${routeNote.location.latitude}, ${routeNote.location.longitude}")
+                routeNote
+              }
+          ).map { note: RouteNote =>
+              logger.info(s"Got message '${note.message}' at " +
+                s"${note.location.latitude}, ${note.location.longitude}")
+            }
+            .onErrorHandle {
+              case e: Throwable =>
+                logger.warn(s"RouteChat Failed: ${Status.fromThrowable(e)} $e")
+                throw e
+            }
+            .completedL
+            .toAsync[F])
 
 }

--- a/modules/examples/todolist/client/src/main/scala/handlers/PingPongClientHandler.scala
+++ b/modules/examples/todolist/client/src/main/scala/handlers/PingPongClientHandler.scala
@@ -17,14 +17,14 @@
 package examples.todolist.client
 package handlers
 
-import cats.Monad.ops._
+import cats.syntax.functor._
 import cats.effect.{Resource, Sync}
 import examples.todolist.client.clients.PingPongClient
 import examples.todolist.protocol.Protocols.PingPongService
 import mu.rpc.protocol.Empty
 import org.log4s._
 
-class PingPongClientHandler[F[_]: Sync](implicit client: Resource[F, PingPongService.Client[F]])
+class PingPongClientHandler[F[_]: Sync](client: Resource[F, PingPongService.Client[F]])
     extends PingPongClient[F] {
 
   val logger: Logger = getLogger

--- a/modules/examples/todolist/client/src/main/scala/handlers/PingPongClientHandler.scala
+++ b/modules/examples/todolist/client/src/main/scala/handlers/PingPongClientHandler.scala
@@ -17,21 +17,21 @@
 package examples.todolist.client
 package handlers
 
-import cats.Functor
-import cats.syntax.functor._
+import cats.Monad.ops._
+import cats.effect.{Resource, Sync}
 import examples.todolist.client.clients.PingPongClient
 import examples.todolist.protocol.Protocols.PingPongService
 import mu.rpc.protocol.Empty
 import org.log4s._
 
-class PingPongClientHandler[F[_]](implicit M: Functor[F], client: PingPongService.Client[F])
+class PingPongClientHandler[F[_]: Sync](implicit client: Resource[F, PingPongService.Client[F]])
     extends PingPongClient[F] {
 
   val logger: Logger = getLogger
 
   override def ping(): F[Unit] =
     client
-      .ping(Empty)
+      .use(_.ping(Empty))
       .map(p => logger.info(s"Pong received with timestamp: ${p.time}"))
 
 }

--- a/modules/examples/todolist/client/src/main/scala/handlers/TagClientHandler.scala
+++ b/modules/examples/todolist/client/src/main/scala/handlers/TagClientHandler.scala
@@ -17,7 +17,8 @@
 package examples.todolist.client
 package handlers
 
-import cats.Monad.ops._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
 import cats.effect.{Resource, Sync}
 import examples.todolist.client.clients.TagClient
 import examples.todolist.protocol._
@@ -25,9 +26,8 @@ import examples.todolist.protocol.Protocols._
 import mu.rpc.protocol.Empty
 import freestyle.tagless.logging.LoggingM
 
-class TagClientHandler[F[_]: Sync](
-    implicit log: LoggingM[F],
-    client: Resource[F, TagRpcService.Client[F]])
+class TagClientHandler[F[_]: Sync](client: Resource[F, TagRpcService.Client[F]])(
+    implicit log: LoggingM[F])
     extends TagClient[F] {
 
   override def reset(): F[Int] =

--- a/modules/examples/todolist/client/src/main/scala/handlers/TagClientHandler.scala
+++ b/modules/examples/todolist/client/src/main/scala/handlers/TagClientHandler.scala
@@ -17,53 +17,52 @@
 package examples.todolist.client
 package handlers
 
-import cats.Monad
 import cats.Monad.ops._
+import cats.effect.{Resource, Sync}
 import examples.todolist.client.clients.TagClient
 import examples.todolist.protocol._
 import examples.todolist.protocol.Protocols._
 import mu.rpc.protocol.Empty
 import freestyle.tagless.logging.LoggingM
 
-class TagClientHandler[F[_]](
-    implicit M: Monad[F],
-    log: LoggingM[F],
-    client: TagRpcService.Client[F])
+class TagClientHandler[F[_]: Sync](
+    implicit log: LoggingM[F],
+    client: Resource[F, TagRpcService.Client[F]])
     extends TagClient[F] {
 
   override def reset(): F[Int] =
     for {
       _ <- log.debug(s"Calling to restart tags data")
-      r <- client.reset(Empty)
+      r <- client.use(_.reset(Empty))
     } yield r.value
 
   override def insert(request: TagRequest): F[Option[TagMessage]] =
     for {
       _ <- log.debug(s"Calling to insert tag with name: ${request.name}")
-      t <- client.insert(request)
+      t <- client.use(_.insert(request))
     } yield t.tag
 
   override def retrieve(id: Int): F[Option[TagMessage]] =
     for {
       _ <- log.debug(s"Calling to get tag with id: $id")
-      r <- client.retrieve(MessageId(id))
+      r <- client.use(_.retrieve(MessageId(id)))
     } yield r.tag
 
   override def list(): F[TagList] =
     for {
       _ <- log.debug(s"Calling to get all tags")
-      r <- client.list(Empty)
+      r <- client.use(_.list(Empty))
     } yield r
 
   override def update(tag: TagMessage): F[Option[TagMessage]] =
     for {
       _ <- log.debug(s"Calling to update tag ${tag.id} with name ${tag.name}")
-      r <- client.update(tag)
+      r <- client.use(_.update(tag))
     } yield r.tag
 
   override def remove(id: Int): F[Int] =
     for {
       _ <- log.debug(s"Calling to delete tag with id: $id")
-      r <- client.destroy(MessageId(id))
+      r <- client.use(_.destroy(MessageId(id)))
     } yield r.value
 }

--- a/modules/examples/todolist/client/src/main/scala/handlers/TodoItemClientHandler.scala
+++ b/modules/examples/todolist/client/src/main/scala/handlers/TodoItemClientHandler.scala
@@ -17,55 +17,54 @@
 package examples.todolist.client
 package handlers
 
-import cats.Monad
 import cats.Monad.ops._
+import cats.effect.{Resource, Sync}
 import examples.todolist.client.clients.TodoItemClient
 import examples.todolist.protocol._
 import examples.todolist.protocol.Protocols._
 import mu.rpc.protocol.Empty
 import freestyle.tagless.logging.LoggingM
 
-class TodoItemClientHandler[F[_]](
-    implicit M: Monad[F],
-    log: LoggingM[F],
-    client: TodoItemRpcService.Client[F])
+class TodoItemClientHandler[F[_]: Sync](
+    implicit log: LoggingM[F],
+    client: Resource[F, TodoItemRpcService.Client[F]])
     extends TodoItemClient[F] {
 
   override def reset(): F[Int] =
     for {
       _ <- log.debug(s"Calling to restart todo items data")
-      r <- client.reset(Empty)
+      r <- client.use(_.reset(Empty))
     } yield r.value
 
   override def insert(request: TodoItemRequest): F[Option[TodoItemMessage]] =
     for {
       _ <- log.debug(
         s"Calling to insert todo item with item ${request.item} to list ${request.todoListId}")
-      t <- client.insert(request)
+      t <- client.use(_.insert(request))
     } yield t.msg
 
   override def retrieve(id: Int): F[Option[TodoItemMessage]] =
     for {
       _ <- log.debug(s"Calling to get todo item with id: $id")
-      r <- client.retrieve(MessageId(id))
+      r <- client.use(_.retrieve(MessageId(id)))
     } yield r.msg
 
   override def list(): F[TodoItemList] =
     for {
       _ <- log.debug(s"Calling to get all todo items")
-      r <- client.list(Empty)
+      r <- client.use(_.list(Empty))
     } yield r
 
   override def update(todoItem: TodoItemMessage): F[Option[TodoItemMessage]] =
     for {
       _ <- log.debug(
         s"Calling to update todo item ${todoItem.id} with item ${todoItem.id} from list ${todoItem.todoListId} and completed status ${todoItem.completed}")
-      r <- client.update(todoItem)
+      r <- client.use(_.update(todoItem))
     } yield r.msg
 
   override def remove(id: Int): F[Int] =
     for {
       _ <- log.debug(s"Calling to delete todo item with id: $id")
-      r <- client.destroy(MessageId(id))
+      r <- client.use(_.destroy(MessageId(id)))
     } yield r.value
 }

--- a/modules/examples/todolist/client/src/main/scala/handlers/TodoItemClientHandler.scala
+++ b/modules/examples/todolist/client/src/main/scala/handlers/TodoItemClientHandler.scala
@@ -17,7 +17,8 @@
 package examples.todolist.client
 package handlers
 
-import cats.Monad.ops._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
 import cats.effect.{Resource, Sync}
 import examples.todolist.client.clients.TodoItemClient
 import examples.todolist.protocol._
@@ -25,9 +26,8 @@ import examples.todolist.protocol.Protocols._
 import mu.rpc.protocol.Empty
 import freestyle.tagless.logging.LoggingM
 
-class TodoItemClientHandler[F[_]: Sync](
-    implicit log: LoggingM[F],
-    client: Resource[F, TodoItemRpcService.Client[F]])
+class TodoItemClientHandler[F[_]: Sync](client: Resource[F, TodoItemRpcService.Client[F]])(
+    implicit log: LoggingM[F])
     extends TodoItemClient[F] {
 
   override def reset(): F[Int] =

--- a/modules/examples/todolist/client/src/main/scala/handlers/TodoListClientHandler.scala
+++ b/modules/examples/todolist/client/src/main/scala/handlers/TodoListClientHandler.scala
@@ -17,7 +17,8 @@
 package examples.todolist.client
 package handlers
 
-import cats.Monad.ops._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
 import cats.effect.{Resource, Sync}
 import examples.todolist.client.clients.TodoListClient
 import examples.todolist.protocol.Protocols._
@@ -25,9 +26,8 @@ import examples.todolist.protocol._
 import mu.rpc.protocol.Empty
 import freestyle.tagless.logging.LoggingM
 
-class TodoListClientHandler[F[_]: Sync](
-    implicit log: LoggingM[F],
-    client: Resource[F, TodoListRpcService.Client[F]])
+class TodoListClientHandler[F[_]: Sync](client: Resource[F, TodoListRpcService.Client[F]])(
+    implicit log: LoggingM[F])
     extends TodoListClient[F] {
 
   override def reset(): F[Int] =

--- a/modules/examples/todolist/client/src/main/scala/handlers/TodoListClientHandler.scala
+++ b/modules/examples/todolist/client/src/main/scala/handlers/TodoListClientHandler.scala
@@ -17,55 +17,54 @@
 package examples.todolist.client
 package handlers
 
-import cats.Monad
 import cats.Monad.ops._
+import cats.effect.{Resource, Sync}
 import examples.todolist.client.clients.TodoListClient
 import examples.todolist.protocol.Protocols._
 import examples.todolist.protocol._
 import mu.rpc.protocol.Empty
 import freestyle.tagless.logging.LoggingM
 
-class TodoListClientHandler[F[_]](
-    implicit M: Monad[F],
-    log: LoggingM[F],
-    client: TodoListRpcService.Client[F])
+class TodoListClientHandler[F[_]: Sync](
+    implicit log: LoggingM[F],
+    client: Resource[F, TodoListRpcService.Client[F]])
     extends TodoListClient[F] {
 
   override def reset(): F[Int] =
     for {
       _ <- log.debug(s"Calling to restart todo list data")
-      r <- client.reset(Empty)
+      r <- client.use(_.reset(Empty))
     } yield r.value
 
   override def insert(request: TodoListRequest): F[Option[TodoListMessage]] =
     for {
       _ <- log.debug(
         s"Calling to insert todo list with name: ${request.title} and id: ${request.tagId}")
-      t <- client.insert(request)
+      t <- client.use(_.insert(request))
     } yield t.msg
 
   override def retrieve(id: Int): F[Option[TodoListMessage]] =
     for {
       _ <- log.debug(s"Calling to get todo list with id: $id")
-      r <- client.retrieve(MessageId(id))
+      r <- client.use(_.retrieve(MessageId(id)))
     } yield r.msg
 
   override def list(): F[TodoListList] =
     for {
       _ <- log.debug(s"Calling to get all todo lists")
-      r <- client.list(Empty)
+      r <- client.use(_.list(Empty))
     } yield r
 
   override def update(todoList: TodoListMessage): F[Option[TodoListMessage]] =
     for {
       _ <- log.debug(
         s"Calling to update todo list with title: ${todoList.title}, tagId: ${todoList.tagId} and id: ${todoList.id}")
-      r <- client.update(todoList)
+      r <- client.use(_.update(todoList))
     } yield r.msg
 
   override def remove(id: Int): F[Int] =
     for {
       _ <- log.debug(s"Calling to delete tag with id: $id")
-      r <- client.destroy(MessageId(id))
+      r <- client.use(_.destroy(MessageId(id)))
     } yield r.value
 }

--- a/modules/examples/todolist/client/src/main/scala/implicits.scala
+++ b/modules/examples/todolist/client/src/main/scala/implicits.scala
@@ -32,29 +32,29 @@ trait ClientImplicits extends CommonRuntime {
   val channelFor: ChannelFor =
     ConfigForAddress[IO]("rpc.client.host", "rpc.client.port").unsafeRunSync()
 
-  implicit val pingPongServiceClient: Resource[IO, PingPongService.Client[IO]] =
+  val pingPongServiceClient: Resource[IO, PingPongService.Client[IO]] =
     PingPongService.client[IO](channelFor)
 
   implicit val pingPongClientHandler: PingPongClientHandler[IO] =
-    new PingPongClientHandler[IO]
+    new PingPongClientHandler[IO](pingPongServiceClient)
 
-  implicit val tagRpcServiceClient: Resource[IO, TagRpcService.Client[IO]] =
+  val tagRpcServiceClient: Resource[IO, TagRpcService.Client[IO]] =
     TagRpcService.client[IO](channelFor)
 
   implicit val tagClientHandler: TagClientHandler[IO] =
-    new TagClientHandler[IO]
+    new TagClientHandler[IO](tagRpcServiceClient)
 
-  implicit val todoListRpcServiceClient: Resource[IO, TodoListRpcService.Client[IO]] =
+  val todoListRpcServiceClient: Resource[IO, TodoListRpcService.Client[IO]] =
     TodoListRpcService.client[IO](channelFor)
 
   implicit val todoListClientHandler: TodoListClientHandler[IO] =
-    new TodoListClientHandler[IO]
+    new TodoListClientHandler[IO](todoListRpcServiceClient)
 
-  implicit val todoItemRpcServiceClient: Resource[IO, TodoItemRpcService.Client[IO]] =
+  val todoItemRpcServiceClient: Resource[IO, TodoItemRpcService.Client[IO]] =
     TodoItemRpcService.client[IO](channelFor)
 
   implicit val todoItemClientHandler: TodoItemClientHandler[IO] =
-    new TodoItemClientHandler[IO]
+    new TodoItemClientHandler[IO](todoItemRpcServiceClient)
 
 }
 

--- a/modules/examples/todolist/client/src/main/scala/implicits.scala
+++ b/modules/examples/todolist/client/src/main/scala/implicits.scala
@@ -16,7 +16,7 @@
 
 package examples.todolist.client
 
-import cats.effect.{ContextShift, IO, Timer}
+import cats.effect.{ContextShift, IO, Resource, Timer}
 import examples.todolist.client.handlers._
 import examples.todolist.protocol.Protocols._
 import freestyle.tagless.loggingJVM.log4s.implicits._
@@ -32,25 +32,25 @@ trait ClientImplicits extends CommonRuntime {
   val channelFor: ChannelFor =
     ConfigForAddress[IO]("rpc.client.host", "rpc.client.port").unsafeRunSync()
 
-  implicit val pingPongServiceClient: PingPongService.Client[IO] =
+  implicit val pingPongServiceClient: Resource[IO, PingPongService.Client[IO]] =
     PingPongService.client[IO](channelFor)
 
   implicit val pingPongClientHandler: PingPongClientHandler[IO] =
     new PingPongClientHandler[IO]
 
-  implicit val tagRpcServiceClient: TagRpcService.Client[IO] =
+  implicit val tagRpcServiceClient: Resource[IO, TagRpcService.Client[IO]] =
     TagRpcService.client[IO](channelFor)
 
   implicit val tagClientHandler: TagClientHandler[IO] =
     new TagClientHandler[IO]
 
-  implicit val todoListRpcServiceClient: TodoListRpcService.Client[IO] =
+  implicit val todoListRpcServiceClient: Resource[IO, TodoListRpcService.Client[IO]] =
     TodoListRpcService.client[IO](channelFor)
 
   implicit val todoListClientHandler: TodoListClientHandler[IO] =
     new TodoListClientHandler[IO]
 
-  implicit val todoItemRpcServiceClient: TodoItemRpcService.Client[IO] =
+  implicit val todoItemRpcServiceClient: Resource[IO, TodoItemRpcService.Client[IO]] =
     TodoItemRpcService.client[IO](channelFor)
 
   implicit val todoItemClientHandler: TodoItemClientHandler[IO] =

--- a/modules/examples/todolist/server/src/main/scala/handlers/TagRpcServiceHandler.scala
+++ b/modules/examples/todolist/server/src/main/scala/handlers/TagRpcServiceHandler.scala
@@ -18,7 +18,7 @@ package examples.todolist.server
 package handlers
 
 import cats.Monad
-import cats.Monad.ops._
+import cats.syntax.functor._
 import examples.todolist.protocol._
 import examples.todolist.protocol.Protocols._
 import examples.todolist.service.TagService

--- a/modules/examples/todolist/server/src/main/scala/handlers/TodoItemRpcServiceHandler.scala
+++ b/modules/examples/todolist/server/src/main/scala/handlers/TodoItemRpcServiceHandler.scala
@@ -18,7 +18,7 @@ package examples.todolist.server
 package handlers
 
 import cats.Monad
-import cats.Monad.ops._
+import cats.syntax.functor._
 import cats.syntax.option._
 import examples.todolist.service.TodoItemService
 import examples.todolist.TodoItem

--- a/modules/examples/todolist/server/src/main/scala/handlers/TodoListRpcServiceHandler.scala
+++ b/modules/examples/todolist/server/src/main/scala/handlers/TodoListRpcServiceHandler.scala
@@ -18,7 +18,7 @@ package examples.todolist.server
 package handlers
 
 import cats.Monad
-import cats.Monad.ops._
+import cats.syntax.functor._
 import cats.syntax.option._
 import examples.todolist.protocol._
 import examples.todolist.protocol.Protocols._

--- a/modules/internal/src/main/scala/service.scala
+++ b/modules/internal/src/main/scala/service.scala
@@ -184,15 +184,15 @@ object serviceImpl {
       private val Client                        = TypeName("Client")
       val clientClass: ClassDef =
         q"""
-        class $Client[F[_]](
+        class $Client[$F_](
           channel: _root_.io.grpc.ManagedChannel,
           options: _root_.io.grpc.CallOptions = _root_.io.grpc.CallOptions.DEFAULT
         )(implicit
-          F: _root_.cats.effect.ConcurrentEffect[F],
+          F: _root_.cats.effect.ConcurrentEffect[$F],
           EC: _root_.scala.concurrent.ExecutionContext
-        ) extends _root_.io.grpc.stub.AbstractStub[$Client[F]](channel, options) {
-          override def build(channel: _root_.io.grpc.Channel, options: _root_.io.grpc.CallOptions): $Client[F] =
-              new $Client[F](channel.asInstanceOf[_root_.io.grpc.ManagedChannel], options)
+        ) extends _root_.io.grpc.stub.AbstractStub[$Client[$F]](channel, options) {
+          override def build(channel: _root_.io.grpc.Channel, options: _root_.io.grpc.CallOptions): $Client[$F] =
+              new $Client[$F](channel.asInstanceOf[_root_.io.grpc.ManagedChannel], options)
 
           ..$clientCallMethods
           ..$nonRpcDefs
@@ -200,33 +200,33 @@ object serviceImpl {
 
       val client: DefDef =
         q"""
-        def client[F[_]](
+        def client[$F_](
           channelFor: _root_.mu.rpc.ChannelFor,
           channelConfigList: List[_root_.mu.rpc.client.ManagedChannelConfig] = List(
             _root_.mu.rpc.client.UsePlaintext()),
             options: _root_.io.grpc.CallOptions = _root_.io.grpc.CallOptions.DEFAULT
           )(implicit
-          F: _root_.cats.effect.ConcurrentEffect[F],
+          F: _root_.cats.effect.ConcurrentEffect[$F],
           EC: _root_.scala.concurrent.ExecutionContext
-        ): _root_.cats.effect.Resource[F, $Client[F]] =
+        ): _root_.cats.effect.Resource[F, $Client[$F]] =
           _root_.cats.effect.Resource.make {
-            val managedChannelInterpreter = new _root_.mu.rpc.client.ManagedChannelInterpreter[F](channelFor, channelConfigList)
+            val managedChannelInterpreter = new _root_.mu.rpc.client.ManagedChannelInterpreter[$F](channelFor, channelConfigList)
             managedChannelInterpreter.build(channelFor, channelConfigList)
           }(channel => F.delay(channel.shutdown())).flatMap(ch =>
-          _root_.cats.effect.Resource.make(F.delay(new $Client[F](ch, options)))(_ => F.unit))
+          _root_.cats.effect.Resource.make(F.delay(new $Client[$F](ch, options)))(_ => F.unit))
         """.supressWarts("DefaultArguments")
 
       val clientFromChannel: DefDef =
         q"""
-        def clientFromChannel[F[_]](
+        def clientFromChannel[$F_](
           channel: F[_root_.io.grpc.ManagedChannel],
           options: _root_.io.grpc.CallOptions = _root_.io.grpc.CallOptions.DEFAULT
         )(implicit
-          F: _root_.cats.effect.ConcurrentEffect[F],
+          F: _root_.cats.effect.ConcurrentEffect[$F],
           EC: _root_.scala.concurrent.ExecutionContext
-        ): _root_.cats.effect.Resource[F, $Client[F]] = _root_.cats.effect.Resource.make(channel)(channel =>
+        ): _root_.cats.effect.Resource[F, $Client[$F]] = _root_.cats.effect.Resource.make(channel)(channel =>
         F.delay(channel.shutdown())).flatMap(ch =>
-        _root_.cats.effect.Resource.make(F.delay(new $Client[F](ch, options)))(_ => F.unit))
+        _root_.cats.effect.Resource.make(F.delay(new $Client[$F](ch, options)))(_ => F.unit))
         """.supressWarts("DefaultArguments")
 
       val unsafeClient: DefDef =
@@ -241,7 +241,7 @@ object serviceImpl {
           EC: _root_.scala.concurrent.ExecutionContext
         ): $Client[$F] = {
           val managedChannelInterpreter =
-            new _root_.mu.rpc.client.ManagedChannelInterpreter[F](channelFor, channelConfigList)
+            new _root_.mu.rpc.client.ManagedChannelInterpreter[$F](channelFor, channelConfigList)
           new $Client[$F](managedChannelInterpreter.unsafeBuild(channelFor, channelConfigList), options)
         }""".supressWarts("DefaultArguments")
 

--- a/modules/internal/src/main/scala/service.scala
+++ b/modules/internal/src/main/scala/service.scala
@@ -212,7 +212,8 @@ object serviceImpl {
           _root_.cats.effect.Resource.make {
             val managedChannelInterpreter = new _root_.mu.rpc.client.ManagedChannelInterpreter[F](channelFor, channelConfigList)
             managedChannelInterpreter.build(channelFor, channelConfigList)
-          }(channel => F.delay(channel.shutdown())).flatMap(ch => _root_.cats.effect.Resource.make(F.delay(new $Client[F](ch, options)))(_ => F.delay(())))
+          }(channel => F.delay(channel.shutdown())).flatMap(ch =>
+          _root_.cats.effect.Resource.make(F.delay(new $Client[F](ch, options)))(_ => F.unit))
         """.supressWarts("DefaultArguments")
 
       val clientFromChannel: DefDef =
@@ -223,35 +224,37 @@ object serviceImpl {
         )(implicit
           F: _root_.cats.effect.ConcurrentEffect[F],
           EC: _root_.scala.concurrent.ExecutionContext
-        ): _root_.cats.effect.Resource[F, $Client[F]] = _root_.cats.effect.Resource.make(channel)(channel => F.delay(channel.shutdown())).flatMap(ch => _root_.cats.effect.Resource.make(F.delay(new $Client[F](ch, options)))(_ => F.delay(())))
+        ): _root_.cats.effect.Resource[F, $Client[F]] = _root_.cats.effect.Resource.make(channel)(channel =>
+        F.delay(channel.shutdown())).flatMap(ch =>
+        _root_.cats.effect.Resource.make(F.delay(new $Client[F](ch, options)))(_ => F.unit))
         """.supressWarts("DefaultArguments")
 
-//      val unsafeClient: DefDef =
-//        q"""
-//        def unsafeClient[$F_](
-//          channelFor: _root_.mu.rpc.ChannelFor,
-//          channelConfigList: List[_root_.mu.rpc.client.ManagedChannelConfig] = List(
-//            _root_.mu.rpc.client.UsePlaintext()),
-//            options: _root_.io.grpc.CallOptions = _root_.io.grpc.CallOptions.DEFAULT
-//          )(implicit
-//          F: _root_.cats.effect.ConcurrentEffect[$F],
-//          EC: _root_.scala.concurrent.ExecutionContext
-//        ): $Client[$F] = {
-//          val managedChannelInterpreter =
-//            new _root_.mu.rpc.client.ManagedChannelInterpreter[F](channelFor, channelConfigList)
-//          new $Client[$F](managedChannelInterpreter.build(channelFor, channelConfigList), options)
-//        }""".supressWarts("DefaultArguments")
-//
-//      val unsafeClientFromChannel: DefDef =
-//        q"""
-//        def unsafeClientFromChannel[$F_](
-//          channel: _root_.io.grpc.Channel,
-//          options: _root_.io.grpc.CallOptions = _root_.io.grpc.CallOptions.DEFAULT
-//        )(implicit
-//          F: _root_.cats.effect.ConcurrentEffect[$F],
-//          EC: _root_.scala.concurrent.ExecutionContext
-//        ): $Client[$F] = new $Client[$F](channel, options)
-//        """.supressWarts("DefaultArguments")
+      val unsafeClient: DefDef =
+        q"""
+        def unsafeClient[$F_](
+          channelFor: _root_.mu.rpc.ChannelFor,
+          channelConfigList: List[_root_.mu.rpc.client.ManagedChannelConfig] = List(
+            _root_.mu.rpc.client.UsePlaintext()),
+            options: _root_.io.grpc.CallOptions = _root_.io.grpc.CallOptions.DEFAULT
+          )(implicit
+          F: _root_.cats.effect.ConcurrentEffect[$F],
+          EC: _root_.scala.concurrent.ExecutionContext
+        ): $Client[$F] = {
+          val managedChannelInterpreter =
+            new _root_.mu.rpc.client.ManagedChannelInterpreter[F](channelFor, channelConfigList)
+          new $Client[$F](managedChannelInterpreter.unsafeBuild(channelFor, channelConfigList), options)
+        }""".supressWarts("DefaultArguments")
+
+      val unsafeClientFromChannel: DefDef =
+        q"""
+        def unsafeClientFromChannel[$F_](
+          channel: _root_.io.grpc.ManagedChannel,
+          options: _root_.io.grpc.CallOptions = _root_.io.grpc.CallOptions.DEFAULT
+        )(implicit
+          F: _root_.cats.effect.ConcurrentEffect[$F],
+          EC: _root_.scala.concurrent.ExecutionContext
+        ): $Client[$F] = new $Client[$F](channel, options)
+        """.supressWarts("DefaultArguments")
 
       private def lit(x: Any): Literal = Literal(Constant(x.toString))
 
@@ -430,7 +433,9 @@ object serviceImpl {
               service.bindService,
               service.clientClass,
               service.client,
-              service.clientFromChannel
+              service.clientFromChannel,
+              service.unsafeClient,
+              service.unsafeClientFromChannel
             )
           )
         )

--- a/modules/internal/src/main/scala/service.scala
+++ b/modules/internal/src/main/scala/service.scala
@@ -226,32 +226,32 @@ object serviceImpl {
         ): _root_.cats.effect.Resource[F, $Client[F]] = _root_.cats.effect.Resource.make(channel)(channel => F.delay(channel.shutdown())).flatMap(ch => _root_.cats.effect.Resource.make(F.delay(new $Client[F](ch, options)))(_ => F.delay(())))
         """.supressWarts("DefaultArguments")
 
-      val unsafeClient: DefDef =
-        q"""
-        def unsafeClient[$F_](
-          channelFor: _root_.mu.rpc.ChannelFor,
-          channelConfigList: List[_root_.mu.rpc.client.ManagedChannelConfig] = List(
-            _root_.mu.rpc.client.UsePlaintext()),
-            options: _root_.io.grpc.CallOptions = _root_.io.grpc.CallOptions.DEFAULT
-          )(implicit
-          F: _root_.cats.effect.ConcurrentEffect[$F],
-          EC: _root_.scala.concurrent.ExecutionContext
-        ): $Client[$F] = {
-          val managedChannelInterpreter =
-            new _root_.mu.rpc.client.ManagedChannelInterpreter[F](channelFor, channelConfigList)
-          new $Client[$F](managedChannelInterpreter.build(channelFor, channelConfigList), options)
-        }""".supressWarts("DefaultArguments")
-
-      val unsafeClientFromChannel: DefDef =
-        q"""
-        def unsafeClientFromChannel[$F_](
-          channel: _root_.io.grpc.Channel,
-          options: _root_.io.grpc.CallOptions = _root_.io.grpc.CallOptions.DEFAULT
-        )(implicit
-          F: _root_.cats.effect.ConcurrentEffect[$F],
-          EC: _root_.scala.concurrent.ExecutionContext
-        ): $Client[$F] = new $Client[$F](channel, options)
-        """.supressWarts("DefaultArguments")
+//      val unsafeClient: DefDef =
+//        q"""
+//        def unsafeClient[$F_](
+//          channelFor: _root_.mu.rpc.ChannelFor,
+//          channelConfigList: List[_root_.mu.rpc.client.ManagedChannelConfig] = List(
+//            _root_.mu.rpc.client.UsePlaintext()),
+//            options: _root_.io.grpc.CallOptions = _root_.io.grpc.CallOptions.DEFAULT
+//          )(implicit
+//          F: _root_.cats.effect.ConcurrentEffect[$F],
+//          EC: _root_.scala.concurrent.ExecutionContext
+//        ): $Client[$F] = {
+//          val managedChannelInterpreter =
+//            new _root_.mu.rpc.client.ManagedChannelInterpreter[F](channelFor, channelConfigList)
+//          new $Client[$F](managedChannelInterpreter.build(channelFor, channelConfigList), options)
+//        }""".supressWarts("DefaultArguments")
+//
+//      val unsafeClientFromChannel: DefDef =
+//        q"""
+//        def unsafeClientFromChannel[$F_](
+//          channel: _root_.io.grpc.Channel,
+//          options: _root_.io.grpc.CallOptions = _root_.io.grpc.CallOptions.DEFAULT
+//        )(implicit
+//          F: _root_.cats.effect.ConcurrentEffect[$F],
+//          EC: _root_.scala.concurrent.ExecutionContext
+//        ): $Client[$F] = new $Client[$F](channel, options)
+//        """.supressWarts("DefaultArguments")
 
       private def lit(x: Any): Literal = Literal(Constant(x.toString))
 
@@ -430,9 +430,7 @@ object serviceImpl {
               service.bindService,
               service.clientClass,
               service.client,
-              service.clientFromChannel,
-              service.unsafeClient,
-              service.unsafeClientFromChannel
+              service.clientFromChannel
             )
           )
         )

--- a/modules/internal/src/main/scala/service.scala
+++ b/modules/internal/src/main/scala/service.scala
@@ -185,14 +185,14 @@ object serviceImpl {
       val clientClass: ClassDef =
         q"""
         class $Client[$F_](
-          channel: _root_.io.grpc.ManagedChannel,
+          channel: _root_.io.grpc.Channel,
           options: _root_.io.grpc.CallOptions = _root_.io.grpc.CallOptions.DEFAULT
         )(implicit
           F: _root_.cats.effect.ConcurrentEffect[$F],
           EC: _root_.scala.concurrent.ExecutionContext
         ) extends _root_.io.grpc.stub.AbstractStub[$Client[$F]](channel, options) {
           override def build(channel: _root_.io.grpc.Channel, options: _root_.io.grpc.CallOptions): $Client[$F] =
-              new $Client[$F](channel.asInstanceOf[_root_.io.grpc.ManagedChannel], options)
+              new $Client[$F](channel, options)
 
           ..$clientCallMethods
           ..$nonRpcDefs
@@ -248,7 +248,7 @@ object serviceImpl {
       val unsafeClientFromChannel: DefDef =
         q"""
         def unsafeClientFromChannel[$F_](
-          channel: _root_.io.grpc.ManagedChannel,
+          channel: _root_.io.grpc.Channel,
           options: _root_.io.grpc.CallOptions = _root_.io.grpc.CallOptions.DEFAULT
         )(implicit
           F: _root_.cats.effect.ConcurrentEffect[$F],

--- a/modules/marshallers/jodatime/src/test/scala/RPCJodaLocalDateTimeTests.scala
+++ b/modules/marshallers/jodatime/src/test/scala/RPCJodaLocalDateTimeTests.scala
@@ -18,8 +18,8 @@ package mu.rpc
 package protocol
 
 import org.joda.time._
-
 import cats.Applicative
+import cats.effect.{IO, Resource}
 import cats.syntax.applicative._
 import com.fortysevendeg.scalacheck.datetime.instances.joda._
 import com.fortysevendeg.scalacheck.datetime.GenDateTime._
@@ -31,6 +31,9 @@ import org.scalacheck.Prop._
 import org.scalatest.prop.Checkers
 
 class RPCJodaLocalDateTimeTests extends RpcBaseTestSuite with BeforeAndAfter with Checkers {
+
+  def withClient[Client, A](resource: Resource[ConcurrentMonad, Client])(f: Client => A): A =
+    resource.use(client => IO(f(client))).unsafeRunSync()
 
   object RPCJodaLocalDateTimeService {
 
@@ -97,15 +100,15 @@ class RPCJodaLocalDateTimeTests extends RpcBaseTestSuite with BeforeAndAfter wit
     "be able to serialize and deserialize joda.time.LocalDateTime using proto format" in {
 
       withServerChannel(ProtobufService.Def.bindService[ConcurrentMonad]) { sc =>
-        val client: ProtobufService.Def.Client[ConcurrentMonad] =
-          ProtobufService.Def.clientFromChannel[ConcurrentMonad](sc.channel)
+        withClient(ProtobufService.Def.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
+          client =>
+            check {
+              forAll(genDateTimeWithinRange(from, range)) { dt: DateTime =>
+                val date = dt.toLocalDateTime
+                client.jodaLocalDateTimeProto(date).unsafeRunSync() == date
 
-        check {
-          forAll(genDateTimeWithinRange(from, range)) { dt: DateTime =>
-            val date = dt.toLocalDateTime
-            client.jodaLocalDateTimeProto(date).unsafeRunSync() == date
-
-          }
+              }
+            }
         }
       }
     }
@@ -113,20 +116,21 @@ class RPCJodaLocalDateTimeTests extends RpcBaseTestSuite with BeforeAndAfter wit
     "be able to serialize and deserialize joda.LocalDateTime in a Request using proto format" in {
 
       withServerChannel(ProtobufService.Def.bindService[ConcurrentMonad]) { sc =>
-        val client: ProtobufService.Def.Client[ConcurrentMonad] =
-          ProtobufService.Def.clientFromChannel[ConcurrentMonad](sc.channel)
-
-        check {
-          forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
-            (dt: DateTime, s: String) =>
-              val date = dt.toLocalDateTime
-              client.jodaLocalDateTimeReqProto(Request(date, s)).unsafeRunSync() == Response(
-                date,
-                s,
-                check = true
-              )
-
-          }
+        withClient(ProtobufService.Def.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
+          client =>
+            check {
+              forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
+                (dt: DateTime, s: String) =>
+                  val date = dt.toLocalDateTime
+                  client
+                    .jodaLocalDateTimeReqProto(Request(date, s))
+                    .unsafeRunSync() == Response(
+                    date,
+                    s,
+                    check = true
+                  )
+              }
+            }
         }
 
       }
@@ -134,14 +138,12 @@ class RPCJodaLocalDateTimeTests extends RpcBaseTestSuite with BeforeAndAfter wit
 
     "be able to serialize and deserialize joda.LocalDateTime using avro format" in {
       withServerChannel(AvroService.Def.bindService[ConcurrentMonad]) { sc =>
-        val client: AvroService.Def.Client[ConcurrentMonad] =
-          AvroService.Def.clientFromChannel[ConcurrentMonad](sc.channel)
-
-        check {
-          forAll(genDateTimeWithinRange(from, range)) { dt: DateTime =>
-            val date = dt.toLocalDateTime
-            client.jodaLocalDateTimeAvro(date).unsafeRunSync() == date
-
+        withClient(AvroService.Def.clientFromChannel[ConcurrentMonad](IO(sc.channel))) { client =>
+          check {
+            forAll(genDateTimeWithinRange(from, range)) { dt: DateTime =>
+              val date = dt.toLocalDateTime
+              client.jodaLocalDateTimeAvro(date).unsafeRunSync() == date
+            }
           }
         }
       }
@@ -150,19 +152,19 @@ class RPCJodaLocalDateTimeTests extends RpcBaseTestSuite with BeforeAndAfter wit
     "be able to serialize and deserialize joda.LocalDateTime in a Request using avro format" in {
 
       withServerChannel(AvroService.Def.bindService[ConcurrentMonad]) { sc =>
-        val client: AvroService.Def.Client[ConcurrentMonad] =
-          AvroService.Def.clientFromChannel[ConcurrentMonad](sc.channel)
-
-        check {
-          forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
-            (dt: DateTime, s: String) =>
-              val date = dt.toLocalDateTime
-              client.jodaLocalDateTimeReqAvro(Request(date, s)).unsafeRunSync() == Response(
-                date,
-                s,
-                check = true
-              )
-
+        withClient(AvroService.Def.clientFromChannel[ConcurrentMonad](IO(sc.channel))) { client =>
+          check {
+            forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
+              (dt: DateTime, s: String) =>
+                val date = dt.toLocalDateTime
+                client
+                  .jodaLocalDateTimeReqAvro(Request(date, s))
+                  .unsafeRunSync() == Response(
+                  date,
+                  s,
+                  check = true
+                )
+            }
           }
         }
       }
@@ -170,15 +172,14 @@ class RPCJodaLocalDateTimeTests extends RpcBaseTestSuite with BeforeAndAfter wit
 
     "be able to serialize and deserialize joda.LocalDateTime using avro with schema format" in {
       withServerChannel(AvroService.WithSchemaDef.bindService[ConcurrentMonad]) { sc =>
-        val client: AvroService.WithSchemaDef.Client[ConcurrentMonad] =
-          AvroService.WithSchemaDef.clientFromChannel[ConcurrentMonad](sc.channel)
-
-        check {
-          forAll(genDateTimeWithinRange(from, range)) { dt: DateTime =>
-            val date = dt.toLocalDateTime
-            client.localDateTimeAvroWithSchema(date).unsafeRunSync() == date
-
-          }
+        withClient(AvroService.WithSchemaDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
+          client =>
+            check {
+              forAll(genDateTimeWithinRange(from, range)) { dt: DateTime =>
+                val date = dt.toLocalDateTime
+                client.localDateTimeAvroWithSchema(date).unsafeRunSync() == date
+              }
+            }
         }
       }
     }
@@ -186,22 +187,21 @@ class RPCJodaLocalDateTimeTests extends RpcBaseTestSuite with BeforeAndAfter wit
     "be able to serialize and deserialize joda.LocalDateTime in a Request using avro with schema format" in {
 
       withServerChannel(AvroService.WithSchemaDef.bindService[ConcurrentMonad]) { sc =>
-        val client: AvroService.WithSchemaDef.Client[ConcurrentMonad] =
-          AvroService.WithSchemaDef.clientFromChannel[ConcurrentMonad](sc.channel)
-
-        check {
-          forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
-            (dt: DateTime, s: String) =>
-              val date = dt.toLocalDateTime
-              client
-                .jodaLocalDateTimeReqAvroWithSchema(Request(date, s))
-                .unsafeRunSync() == Response(
-                date,
-                s,
-                check = true
-              )
-
-          }
+        withClient(AvroService.WithSchemaDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
+          client =>
+            check {
+              forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
+                (dt: DateTime, s: String) =>
+                  val date = dt.toLocalDateTime
+                  client
+                    .jodaLocalDateTimeReqAvroWithSchema(Request(date, s))
+                    .unsafeRunSync() == Response(
+                    date,
+                    s,
+                    check = true
+                  )
+              }
+            }
         }
       }
     }

--- a/modules/prometheus/client/src/test/scala/InterceptorsRuntime.scala
+++ b/modules/prometheus/client/src/test/scala/InterceptorsRuntime.scala
@@ -18,6 +18,7 @@ package mu.rpc
 package prometheus
 package client
 
+import cats.effect.Resource
 import mu.rpc.client._
 import mu.rpc.common.ConcurrentMonad
 import mu.rpc.prometheus.shared.Configuration
@@ -58,20 +59,25 @@ case class InterceptorsRuntime(
     AddInterceptor(MonitoringClientInterceptor(configuration.withCollectorRegistry(cr)))
   )
 
-  implicit lazy val muProtoRPCServiceClient: ProtoRPCService.Client[ConcurrentMonad] =
+  implicit lazy val muProtoRPCServiceClient: Resource[
+    ConcurrentMonad,
+    ProtoRPCService.Client[ConcurrentMonad]] =
     ProtoRPCService.client[ConcurrentMonad](
       channelFor = createChannelForPort(pickUnusedPort),
       channelConfigList = configList
     )
 
-  implicit lazy val muAvroRPCServiceClient: AvroRPCService.Client[ConcurrentMonad] =
+  implicit lazy val muAvroRPCServiceClient: Resource[
+    ConcurrentMonad,
+    AvroRPCService.Client[ConcurrentMonad]] =
     AvroRPCService.client[ConcurrentMonad](
       channelFor = createChannelForPort(pickUnusedPort),
       channelConfigList = configList
     )
 
-  implicit lazy val muAvroWithSchemaRPCServiceClient: AvroWithSchemaRPCService.Client[
-    ConcurrentMonad] =
+  implicit lazy val muAvroWithSchemaRPCServiceClient: Resource[
+    ConcurrentMonad,
+    AvroWithSchemaRPCService.Client[ConcurrentMonad]] =
     AvroWithSchemaRPCService.client[ConcurrentMonad](
       channelFor = createChannelForPort(pickUnusedPort),
       channelConfigList = configList

--- a/modules/prometheus/server/src/test/scala/InterceptorsRuntime.scala
+++ b/modules/prometheus/server/src/test/scala/InterceptorsRuntime.scala
@@ -18,6 +18,7 @@ package mu.rpc
 package prometheus
 package server
 
+import cats.effect.Resource
 import mu.rpc.common.ConcurrentMonad
 import mu.rpc.prometheus.shared.Configuration
 import mu.rpc.protocol.Utils._
@@ -60,18 +61,23 @@ case class InterceptorsRuntime(
   // Client Runtime Configuration //
   //////////////////////////////////
 
-  implicit lazy val muProtoRPCServiceClient: ProtoRPCService.Client[ConcurrentMonad] =
+  implicit lazy val muProtoRPCServiceClient: Resource[
+    ConcurrentMonad,
+    ProtoRPCService.Client[ConcurrentMonad]] =
     ProtoRPCService.client[ConcurrentMonad](
       channelFor = createChannelForPort(pickUnusedPort)
     )
 
-  implicit lazy val muAvroRPCServiceClient: AvroRPCService.Client[ConcurrentMonad] =
+  implicit lazy val muAvroRPCServiceClient: Resource[
+    ConcurrentMonad,
+    AvroRPCService.Client[ConcurrentMonad]] =
     AvroRPCService.client[ConcurrentMonad](
       channelFor = createChannelForPort(pickUnusedPort)
     )
 
-  implicit lazy val muAvroWithSchemaRPCServiceClient: AvroWithSchemaRPCService.Client[
-    ConcurrentMonad] =
+  implicit lazy val muAvroWithSchemaRPCServiceClient: Resource[
+    ConcurrentMonad,
+    AvroWithSchemaRPCService.Client[ConcurrentMonad]] =
     AvroWithSchemaRPCService.client[ConcurrentMonad](
       channelFor = createChannelForPort(pickUnusedPort)
     )

--- a/modules/server/src/main/scala/GrpcServer.scala
+++ b/modules/server/src/main/scala/GrpcServer.scala
@@ -21,7 +21,6 @@ import cats.~>
 import cats.effect.{Effect, IO, Sync}
 import cats.instances.either._
 import cats.syntax.apply._
-import cats.syntax.either._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 import io.grpc.{Server, ServerBuilder, ServerServiceDefinition}

--- a/modules/server/src/test/scala/CommonUtils.scala
+++ b/modules/server/src/test/scala/CommonUtils.scala
@@ -19,7 +19,7 @@ package mu.rpc
 import java.net.ServerSocket
 
 import cats.Functor
-import cats.effect.Sync
+import cats.effect.{IO, Resource, Sync}
 import cats.syntax.functor._
 import mu.rpc.common._
 import mu.rpc.server._
@@ -85,4 +85,7 @@ trait CommonUtils {
       case Failure(e) =>
         throw new RuntimeException(e)
     }
+
+  def withClient[Client, A](resource: Resource[ConcurrentMonad, Client])(f: Client => A): A =
+    resource.use(client => IO(f(client))).unsafeRunSync()
 }

--- a/modules/server/src/test/scala/avro/Utils.scala
+++ b/modules/server/src/test/scala/avro/Utils.scala
@@ -393,7 +393,7 @@ object Utils extends CommonUtils {
     // Client Runtime Configuration //
     //////////////////////////////////
 
-    implicit val muRPCServiceClient: service.RPCService.Client[ConcurrentMonad] =
+    implicit val muRPCServiceClient: ConcurrentMonad[service.RPCService.Client[ConcurrentMonad]] =
       service.RPCService.client[ConcurrentMonad](createChannelFor)
 
   }

--- a/modules/server/src/test/scala/avro/Utils.scala
+++ b/modules/server/src/test/scala/avro/Utils.scala
@@ -19,7 +19,7 @@ package avro
 
 import mu.rpc.common._
 import mu.rpc.protocol._
-import cats.effect.{ConcurrentEffect, Effect}
+import cats.effect.{ConcurrentEffect, Effect, Resource}
 import shapeless.{:+:, CNil, Coproduct}
 
 object Utils extends CommonUtils {
@@ -393,7 +393,9 @@ object Utils extends CommonUtils {
     // Client Runtime Configuration //
     //////////////////////////////////
 
-    implicit val muRPCServiceClient: ConcurrentMonad[service.RPCService.Client[ConcurrentMonad]] =
+    implicit val muRPCServiceClient: Resource[
+      ConcurrentMonad,
+      service.RPCService.Client[ConcurrentMonad]] =
       service.RPCService.client[ConcurrentMonad](createChannelFor)
 
   }

--- a/modules/server/src/test/scala/fs2/Utils.scala
+++ b/modules/server/src/test/scala/fs2/Utils.scala
@@ -20,7 +20,7 @@ package fs2
 import mu.rpc.common._
 import mu.rpc.protocol._
 import _root_.fs2._
-import cats.effect.Effect
+import cats.effect.{Effect, Resource}
 import io.grpc.Status
 
 object Utils extends CommonUtils {
@@ -167,21 +167,29 @@ object Utils extends CommonUtils {
     // Client Runtime Configuration //
     //////////////////////////////////
 
-    implicit val muProtoRPCServiceClient: ConcurrentMonad[ProtoRPCService.Client[ConcurrentMonad]] =
+    implicit val muProtoRPCServiceClient: Resource[
+      ConcurrentMonad,
+      ProtoRPCService.Client[ConcurrentMonad]] =
       ProtoRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val muAvroRPCServiceClient: ConcurrentMonad[AvroRPCService.Client[ConcurrentMonad]] =
+    implicit val muAvroRPCServiceClient: Resource[
+      ConcurrentMonad,
+      AvroRPCService.Client[ConcurrentMonad]] =
       AvroRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val muAvroWithSchemaRPCServiceClient: ConcurrentMonad[AvroWithSchemaRPCService.Client[
-      ConcurrentMonad]] =
+    implicit val muAvroWithSchemaRPCServiceClient: Resource[
+      ConcurrentMonad,
+      AvroWithSchemaRPCService.Client[ConcurrentMonad]] =
       AvroWithSchemaRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val muCompressedProtoRPCServiceClient: ConcurrentMonad[CompressedProtoRPCService.Client[
-      ConcurrentMonad]] =
+    implicit val muCompressedProtoRPCServiceClient: Resource[
+      ConcurrentMonad,
+      CompressedProtoRPCService.Client[ConcurrentMonad]] =
       CompressedProtoRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val muCompressedAvroRPCServiceClient: ConcurrentMonad[CompressedAvroRPCService.Client[
-      ConcurrentMonad]] =
+    implicit val muCompressedAvroRPCServiceClient: Resource[
+      ConcurrentMonad,
+      CompressedAvroRPCService.Client[ConcurrentMonad]] =
       CompressedAvroRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val muCompressedAvroWithSchemaRPCServiceClient: ConcurrentMonad[CompressedAvroWithSchemaRPCService.Client[
-      ConcurrentMonad]] =
+    implicit val muCompressedAvroWithSchemaRPCServiceClient: Resource[
+      ConcurrentMonad,
+      CompressedAvroWithSchemaRPCService.Client[ConcurrentMonad]] =
       CompressedAvroWithSchemaRPCService.client[ConcurrentMonad](createChannelFor)
 
   }

--- a/modules/server/src/test/scala/fs2/Utils.scala
+++ b/modules/server/src/test/scala/fs2/Utils.scala
@@ -167,21 +167,21 @@ object Utils extends CommonUtils {
     // Client Runtime Configuration //
     //////////////////////////////////
 
-    implicit val muProtoRPCServiceClient: ProtoRPCService.Client[ConcurrentMonad] =
+    implicit val muProtoRPCServiceClient: ConcurrentMonad[ProtoRPCService.Client[ConcurrentMonad]] =
       ProtoRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val muAvroRPCServiceClient: AvroRPCService.Client[ConcurrentMonad] =
+    implicit val muAvroRPCServiceClient: ConcurrentMonad[AvroRPCService.Client[ConcurrentMonad]] =
       AvroRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val muAvroWithSchemaRPCServiceClient: AvroWithSchemaRPCService.Client[
-      ConcurrentMonad] =
+    implicit val muAvroWithSchemaRPCServiceClient: ConcurrentMonad[AvroWithSchemaRPCService.Client[
+      ConcurrentMonad]] =
       AvroWithSchemaRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val muCompressedProtoRPCServiceClient: CompressedProtoRPCService.Client[
-      ConcurrentMonad] =
+    implicit val muCompressedProtoRPCServiceClient: ConcurrentMonad[CompressedProtoRPCService.Client[
+      ConcurrentMonad]] =
       CompressedProtoRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val muCompressedAvroRPCServiceClient: CompressedAvroRPCService.Client[
-      ConcurrentMonad] =
+    implicit val muCompressedAvroRPCServiceClient: ConcurrentMonad[CompressedAvroRPCService.Client[
+      ConcurrentMonad]] =
       CompressedAvroRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val muCompressedAvroWithSchemaRPCServiceClient: CompressedAvroWithSchemaRPCService.Client[
-      ConcurrentMonad] =
+    implicit val muCompressedAvroWithSchemaRPCServiceClient: ConcurrentMonad[CompressedAvroWithSchemaRPCService.Client[
+      ConcurrentMonad]] =
       CompressedAvroWithSchemaRPCService.client[ConcurrentMonad](createChannelFor)
 
   }

--- a/modules/server/src/test/scala/protocol/RPCBigDecimalTests.scala
+++ b/modules/server/src/test/scala/protocol/RPCBigDecimalTests.scala
@@ -141,8 +141,8 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
     "be able to serialize and deserialize BigDecimal using proto format" in {
 
       withServerChannel(ProtoRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: ProtoRPCServiceDef.Client[ConcurrentMonad] =
-          ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+        val client: ConcurrentMonad[ProtoRPCServiceDef.Client[ConcurrentMonad]] =
+          ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](IO.pure(sc.channel))
 
         check {
           forAll { bd: BigDecimal =>
@@ -158,7 +158,7 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
       withServerChannel(ProtoRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
         val client: ProtoRPCServiceDef.Client[ConcurrentMonad] =
-          ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+          ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll { (bd: BigDecimal, s: String) =>
@@ -177,7 +177,7 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
       withServerChannel(AvroRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
         val client: AvroRPCServiceDef.Client[ConcurrentMonad] =
-          AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+          AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll(bigDecimalGen(2)) { bd =>
@@ -193,7 +193,7 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
       withServerChannel(AvroRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
         val client: AvroRPCServiceDef.Client[ConcurrentMonad] =
-          AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+          AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll { request: RequestPS =>
@@ -214,7 +214,7 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
       withServerChannel(AvroWithSchemaRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
         val client: AvroWithSchemaRPCServiceDef.Client[ConcurrentMonad] =
-          AvroWithSchemaRPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+          AvroWithSchemaRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll(bigDecimalGen(2)) { bd =>
@@ -232,7 +232,7 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
       withServerChannel(AvroWithSchemaRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
         val client: AvroWithSchemaRPCServiceDef.Client[ConcurrentMonad] =
-          AvroWithSchemaRPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+          AvroWithSchemaRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll { request: RequestPS =>

--- a/modules/server/src/test/scala/protocol/RPCJavaTimeTests.scala
+++ b/modules/server/src/test/scala/protocol/RPCJavaTimeTests.scala
@@ -28,6 +28,7 @@ import com.fortysevendeg.scalacheck.datetime.jdk8.granularity.seconds
 import mu.rpc.common._
 import mu.rpc.internal.encoders.avro.javatime.marshallers._
 import mu.rpc.internal.encoders.pbd.javatime._
+import mu.rpc.protocol.Utils.withClient
 import mu.rpc.testing.servers.withServerChannel
 import org.scalacheck.Arbitrary
 import org.scalatest._
@@ -109,16 +110,15 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDate using proto format" in {
 
       withServerChannel(ProtoRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: ConcurrentMonad[ProtoRPCDateServiceDef.Client[ConcurrentMonad]] =
-          ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
-
-        check {
-          forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
-            val date = zdt.toLocalDate
-            client.localDateProto(date).unsafeRunSync() == date
-          }
+        withClient(ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
+          client =>
+            check {
+              forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
+                val date = zdt.toLocalDate
+                client.localDateProto(date).unsafeRunSync() == date
+              }
+            }
         }
-
       }
 
     }
@@ -126,16 +126,15 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDateTime using proto format" in {
 
       withServerChannel(ProtoRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: ConcurrentMonad[ProtoRPCDateServiceDef.Client[ConcurrentMonad]] =
-          ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
-
-        check {
-          forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
-            val dateTime = zdt.toLocalDateTime
-            client.localDateTimeProto(dateTime).unsafeRunSync() == dateTime
-          }
+        withClient(ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
+          client =>
+            check {
+              forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
+                val dateTime = zdt.toLocalDateTime
+                client.localDateTimeProto(dateTime).unsafeRunSync() == dateTime
+              }
+            }
         }
-
       }
 
     }
@@ -143,16 +142,15 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize Instant using proto format" in {
 
       withServerChannel(ProtoRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: ConcurrentMonad[ProtoRPCDateServiceDef.Client[ConcurrentMonad]] =
-          ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
-
-        check {
-          forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
-            val instant = zdt.toInstant
-            client.instantProto(instant).unsafeRunSync() == instant
-          }
+        withClient(ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
+          client =>
+            check {
+              forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
+                val instant = zdt.toInstant
+                client.instantProto(instant).unsafeRunSync() == instant
+              }
+            }
         }
-
       }
 
     }
@@ -160,21 +158,20 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDate, LocalDateTime, and Instant in a Request using proto format" in {
 
       withServerChannel(ProtoRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: ConcurrentMonad[ProtoRPCDateServiceDef.Client[ConcurrentMonad]] =
-          ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
-
-        check {
-          forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
-            (zdt: ZonedDateTime, s: String) =>
-              val date     = zdt.toLocalDate
-              val dateTime = zdt.toLocalDateTime
-              val instant  = zdt.toInstant
-              client
-                .dateProtoWrapper(Request(date, dateTime, instant, s))
-                .unsafeRunSync() == Response(date, dateTime, instant, s, check = true)
-          }
+        withClient(ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
+          client =>
+            check {
+              forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
+                (zdt: ZonedDateTime, s: String) =>
+                  val date     = zdt.toLocalDate
+                  val dateTime = zdt.toLocalDateTime
+                  val instant  = zdt.toInstant
+                  client
+                    .dateProtoWrapper(Request(date, dateTime, instant, s))
+                    .unsafeRunSync() == Response(date, dateTime, instant, s, check = true)
+              }
+            }
         }
-
       }
 
     }
@@ -182,16 +179,15 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDate using avro format" in {
 
       withServerChannel(AvroRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: ConcurrentMonad[AvroRPCDateServiceDef.Client[ConcurrentMonad]] =
-          AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
-
-        check {
-          forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
-            val date = zdt.toLocalDate
-            client.localDateAvro(date).unsafeRunSync() == date
-          }
+        withClient(AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
+          client =>
+            check {
+              forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
+                val date = zdt.toLocalDate
+                client.localDateAvro(date).unsafeRunSync() == date
+              }
+            }
         }
-
       }
 
     }
@@ -199,16 +195,15 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDateTime using avro format" in {
 
       withServerChannel(AvroRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: ConcurrentMonad[AvroRPCDateServiceDef.Client[ConcurrentMonad]] =
-          AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
-
-        check {
-          forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
-            val dateTime = zdt.toLocalDateTime
-            client.localDateTimeAvro(dateTime).unsafeRunSync() == dateTime
-          }
+        withClient(AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
+          client =>
+            check {
+              forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
+                val dateTime = zdt.toLocalDateTime
+                client.localDateTimeAvro(dateTime).unsafeRunSync() == dateTime
+              }
+            }
         }
-
       }
 
     }
@@ -216,16 +211,15 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize Instant using avro format" in {
 
       withServerChannel(AvroRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: ConcurrentMonad[AvroRPCDateServiceDef.Client[ConcurrentMonad]] =
-          AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
-
-        check {
-          forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
-            val instant = zdt.toInstant
-            client.instantAvro(instant).unsafeRunSync() == instant
-          }
+        withClient(AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
+          client =>
+            check {
+              forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
+                val instant = zdt.toInstant
+                client.instantAvro(instant).unsafeRunSync() == instant
+              }
+            }
         }
-
       }
 
     }
@@ -233,21 +227,20 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDate, LocalDateTime, and Instant in a Request using avro format" in {
 
       withServerChannel(AvroRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: ConcurrentMonad[AvroRPCDateServiceDef.Client[ConcurrentMonad]] =
-          AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
-
-        check {
-          forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
-            (zdt: ZonedDateTime, s: String) =>
-              val date     = zdt.toLocalDate
-              val dateTime = zdt.toLocalDateTime
-              val instant  = zdt.toInstant
-              client
-                .dateAvroWrapper(Request(date, dateTime, instant, s))
-                .unsafeRunSync() == Response(date, dateTime, instant, s, check = true)
-          }
+        withClient(AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
+          client =>
+            check {
+              forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
+                (zdt: ZonedDateTime, s: String) =>
+                  val date     = zdt.toLocalDate
+                  val dateTime = zdt.toLocalDateTime
+                  val instant  = zdt.toInstant
+                  client
+                    .dateAvroWrapper(Request(date, dateTime, instant, s))
+                    .unsafeRunSync() == Response(date, dateTime, instant, s, check = true)
+              }
+            }
         }
-
       }
 
     }
@@ -255,16 +248,16 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDate using avro format with schema" in {
 
       withServerChannel(AvroWithSchemaRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: ConcurrentMonad[AvroWithSchemaRPCDateServiceDef.Client[ConcurrentMonad]] =
-          AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
-
-        check {
-          forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
-            val date = zdt.toLocalDate
-            client.localDateAvroWithSchema(date).unsafeRunSync() == date
-          }
+        withClient(
+          AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
+          client =>
+            check {
+              forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
+                val date = zdt.toLocalDate
+                client.localDateAvroWithSchema(date).unsafeRunSync() == date
+              }
+            }
         }
-
       }
 
     }
@@ -272,16 +265,16 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDateTime using avro format with schema" in {
 
       withServerChannel(AvroWithSchemaRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: ConcurrentMonad[AvroWithSchemaRPCDateServiceDef.Client[ConcurrentMonad]] =
-          AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
-
-        check {
-          forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
-            val dateTime = zdt.toLocalDateTime
-            client.localDateTimeAvroWithSchema(dateTime).unsafeRunSync() == dateTime
-          }
+        withClient(
+          AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
+          client =>
+            check {
+              forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
+                val dateTime = zdt.toLocalDateTime
+                client.localDateTimeAvroWithSchema(dateTime).unsafeRunSync() == dateTime
+              }
+            }
         }
-
       }
 
     }
@@ -289,16 +282,16 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize Instant using avro format with schema" in {
 
       withServerChannel(AvroWithSchemaRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: ConcurrentMonad[AvroWithSchemaRPCDateServiceDef.Client[ConcurrentMonad]] =
-          AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
-
-        check {
-          forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
-            val instant = zdt.toInstant
-            client.instantAvroWithSchema(instant).unsafeRunSync() == instant
-          }
+        withClient(
+          AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
+          client =>
+            check {
+              forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
+                val instant = zdt.toInstant
+                client.instantAvroWithSchema(instant).unsafeRunSync() == instant
+              }
+            }
         }
-
       }
 
     }
@@ -306,21 +299,21 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDate, LocalDateTime, and Instant in a Request using avro format with schema" in {
 
       withServerChannel(AvroWithSchemaRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: ConcurrentMonad[AvroWithSchemaRPCDateServiceDef.Client[ConcurrentMonad]] =
-          AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
-
-        check {
-          forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
-            (zdt: ZonedDateTime, s: String) =>
-              val date     = zdt.toLocalDate
-              val dateTime = zdt.toLocalDateTime
-              val instant  = zdt.toInstant
-              client
-                .dateAvroWrapperWithSchema(Request(date, dateTime, instant, s))
-                .unsafeRunSync() == Response(date, dateTime, instant, s, check = true)
-          }
+        withClient(
+          AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
+          client =>
+            check {
+              forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
+                (zdt: ZonedDateTime, s: String) =>
+                  val date     = zdt.toLocalDate
+                  val dateTime = zdt.toLocalDateTime
+                  val instant  = zdt.toInstant
+                  client
+                    .dateAvroWrapperWithSchema(Request(date, dateTime, instant, s))
+                    .unsafeRunSync() == Response(date, dateTime, instant, s, check = true)
+              }
+            }
         }
-
       }
 
     }

--- a/modules/server/src/test/scala/protocol/RPCJavaTimeTests.scala
+++ b/modules/server/src/test/scala/protocol/RPCJavaTimeTests.scala
@@ -20,6 +20,7 @@ package protocol
 import java.time._
 
 import cats.Applicative
+import cats.effect.IO
 import cats.syntax.applicative._
 import com.fortysevendeg.scalacheck.datetime.instances.jdk8._
 import com.fortysevendeg.scalacheck.datetime.GenDateTime._
@@ -108,8 +109,8 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDate using proto format" in {
 
       withServerChannel(ProtoRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: ProtoRPCDateServiceDef.Client[ConcurrentMonad] =
-          ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+        val client: ConcurrentMonad[ProtoRPCDateServiceDef.Client[ConcurrentMonad]] =
+          ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
@@ -125,8 +126,8 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDateTime using proto format" in {
 
       withServerChannel(ProtoRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: ProtoRPCDateServiceDef.Client[ConcurrentMonad] =
-          ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+        val client: ConcurrentMonad[ProtoRPCDateServiceDef.Client[ConcurrentMonad]] =
+          ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
@@ -142,8 +143,8 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize Instant using proto format" in {
 
       withServerChannel(ProtoRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: ProtoRPCDateServiceDef.Client[ConcurrentMonad] =
-          ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+        val client: ConcurrentMonad[ProtoRPCDateServiceDef.Client[ConcurrentMonad]] =
+          ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
@@ -159,8 +160,8 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDate, LocalDateTime, and Instant in a Request using proto format" in {
 
       withServerChannel(ProtoRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: ProtoRPCDateServiceDef.Client[ConcurrentMonad] =
-          ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+        val client: ConcurrentMonad[ProtoRPCDateServiceDef.Client[ConcurrentMonad]] =
+          ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
@@ -181,8 +182,8 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDate using avro format" in {
 
       withServerChannel(AvroRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: AvroRPCDateServiceDef.Client[ConcurrentMonad] =
-          AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+        val client: ConcurrentMonad[AvroRPCDateServiceDef.Client[ConcurrentMonad]] =
+          AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
@@ -198,8 +199,8 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDateTime using avro format" in {
 
       withServerChannel(AvroRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: AvroRPCDateServiceDef.Client[ConcurrentMonad] =
-          AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+        val client: ConcurrentMonad[AvroRPCDateServiceDef.Client[ConcurrentMonad]] =
+          AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
@@ -215,8 +216,8 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize Instant using avro format" in {
 
       withServerChannel(AvroRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: AvroRPCDateServiceDef.Client[ConcurrentMonad] =
-          AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+        val client: ConcurrentMonad[AvroRPCDateServiceDef.Client[ConcurrentMonad]] =
+          AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
@@ -232,8 +233,8 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDate, LocalDateTime, and Instant in a Request using avro format" in {
 
       withServerChannel(AvroRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: AvroRPCDateServiceDef.Client[ConcurrentMonad] =
-          AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+        val client: ConcurrentMonad[AvroRPCDateServiceDef.Client[ConcurrentMonad]] =
+          AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
@@ -254,8 +255,8 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDate using avro format with schema" in {
 
       withServerChannel(AvroWithSchemaRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: AvroWithSchemaRPCDateServiceDef.Client[ConcurrentMonad] =
-          AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+        val client: ConcurrentMonad[AvroWithSchemaRPCDateServiceDef.Client[ConcurrentMonad]] =
+          AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
@@ -271,8 +272,8 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDateTime using avro format with schema" in {
 
       withServerChannel(AvroWithSchemaRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: AvroWithSchemaRPCDateServiceDef.Client[ConcurrentMonad] =
-          AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+        val client: ConcurrentMonad[AvroWithSchemaRPCDateServiceDef.Client[ConcurrentMonad]] =
+          AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
@@ -288,8 +289,8 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize Instant using avro format with schema" in {
 
       withServerChannel(AvroWithSchemaRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: AvroWithSchemaRPCDateServiceDef.Client[ConcurrentMonad] =
-          AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+        val client: ConcurrentMonad[AvroWithSchemaRPCDateServiceDef.Client[ConcurrentMonad]] =
+          AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
@@ -305,8 +306,8 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize LocalDate, LocalDateTime, and Instant in a Request using avro format with schema" in {
 
       withServerChannel(AvroWithSchemaRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: AvroWithSchemaRPCDateServiceDef.Client[ConcurrentMonad] =
-          AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+        val client: ConcurrentMonad[AvroWithSchemaRPCDateServiceDef.Client[ConcurrentMonad]] =
+          AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))
 
         check {
           forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {

--- a/modules/server/src/test/scala/protocol/RPCProtoProducts.scala
+++ b/modules/server/src/test/scala/protocol/RPCProtoProducts.scala
@@ -18,8 +18,10 @@ package mu.rpc
 package protocol
 
 import cats.Applicative
+import cats.effect.IO
 import cats.syntax.applicative._
 import mu.rpc.common._
+import mu.rpc.protocol.Utils.withClient
 import mu.rpc.testing.servers.withServerChannel
 import org.scalatest._
 import org.scalacheck.Prop._
@@ -90,15 +92,15 @@ class RPCProtoProducts extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize Options in the request/response using proto format" in {
 
       withServerChannel(ProtoRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: ProtoRPCServiceDef.Client[ConcurrentMonad] =
-          ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
-
-        check {
-          forAll { maybeString: Option[String] =>
-            client
-              .optionProto(RequestOption(maybeString.map(MyParam)))
-              .unsafeRunSync() == ResponseOption(maybeString, true)
-          }
+        withClient(ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
+          client =>
+            check {
+              forAll { maybeString: Option[String] =>
+                client
+                  .optionProto(RequestOption(maybeString.map(MyParam)))
+                  .unsafeRunSync() == ResponseOption(maybeString, true)
+              }
+            }
         }
 
       }
@@ -108,17 +110,15 @@ class RPCProtoProducts extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize Options in the request/response using avro format" in {
 
       withServerChannel(AvroRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: AvroRPCServiceDef.Client[ConcurrentMonad] =
-          AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
-
-        check {
-          forAll { maybeString: Option[String] =>
-            client
-              .optionAvro(RequestOption(maybeString.map(MyParam)))
-              .unsafeRunSync() == ResponseOption(maybeString, true)
+        withClient(AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) { client =>
+          check {
+            forAll { maybeString: Option[String] =>
+              client
+                .optionAvro(RequestOption(maybeString.map(MyParam)))
+                .unsafeRunSync() == ResponseOption(maybeString, true)
+            }
           }
         }
-
       }
 
     }
@@ -126,17 +126,16 @@ class RPCProtoProducts extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize Options in the request/response using avro with schema format" in {
 
       withServerChannel(AvroWithSchemaRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: AvroWithSchemaRPCServiceDef.Client[ConcurrentMonad] =
-          AvroWithSchemaRPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
-
-        check {
-          forAll { maybeString: Option[String] =>
-            client
-              .optionAvroWithSchema(RequestOption(maybeString.map(MyParam)))
-              .unsafeRunSync() == ResponseOption(maybeString, true)
-          }
+        withClient(AvroWithSchemaRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
+          client =>
+            check {
+              forAll { maybeString: Option[String] =>
+                client
+                  .optionAvroWithSchema(RequestOption(maybeString.map(MyParam)))
+                  .unsafeRunSync() == ResponseOption(maybeString, true)
+              }
+            }
         }
-
       }
 
     }
@@ -144,17 +143,16 @@ class RPCProtoProducts extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize Lists in the request/response using proto format" in {
 
       withServerChannel(ProtoRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: ProtoRPCServiceDef.Client[ConcurrentMonad] =
-          ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
-
-        check {
-          forAll { list: List[String] =>
-            client
-              .listProto(RequestList(list.map(MyParam)))
-              .unsafeRunSync() == ResponseList(list, true)
-          }
+        withClient(ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
+          client =>
+            check {
+              forAll { list: List[String] =>
+                client
+                  .listProto(RequestList(list.map(MyParam)))
+                  .unsafeRunSync() == ResponseList(list, true)
+              }
+            }
         }
-
       }
 
     }
@@ -162,17 +160,15 @@ class RPCProtoProducts extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize Lists in the request/response using avro format" in {
 
       withServerChannel(AvroRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: AvroRPCServiceDef.Client[ConcurrentMonad] =
-          AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
-
-        check {
-          forAll { list: List[String] =>
-            client
-              .listAvro(RequestList(list.map(MyParam)))
-              .unsafeRunSync() == ResponseList(list, true)
+        withClient(AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) { client =>
+          check {
+            forAll { list: List[String] =>
+              client
+                .listAvro(RequestList(list.map(MyParam)))
+                .unsafeRunSync() == ResponseList(list, true)
+            }
           }
         }
-
       }
 
     }
@@ -180,17 +176,16 @@ class RPCProtoProducts extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
     "be able to serialize and deserialize Lists in the request/response using avro with schema format" in {
 
       withServerChannel(AvroWithSchemaRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
-        val client: AvroWithSchemaRPCServiceDef.Client[ConcurrentMonad] =
-          AvroWithSchemaRPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
-
-        check {
-          forAll { list: List[String] =>
-            client
-              .listAvroWithSchema(RequestList(list.map(MyParam)))
-              .unsafeRunSync() == ResponseList(list, true)
-          }
+        withClient(AvroWithSchemaRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
+          client =>
+            check {
+              forAll { list: List[String] =>
+                client
+                  .listAvroWithSchema(RequestList(list.map(MyParam)))
+                  .unsafeRunSync() == ResponseList(list, true)
+              }
+            }
         }
-
       }
 
     }

--- a/modules/server/src/test/scala/protocol/RPCTests.scala
+++ b/modules/server/src/test/scala/protocol/RPCTests.scala
@@ -17,6 +17,7 @@
 package mu.rpc
 package protocol
 
+import cats.effect.{Bracket, Resource}
 import cats.{Monad, MonadError}
 import cats.syntax.flatMap._
 import cats.syntax.functor._
@@ -258,9 +259,10 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
     "be able to have non request methods" in {
 
-      def clientProgram[F[_]: cats.Functor](
-          implicit client: service.ProtoRPCService.Client[F]): F[Int] =
-        client.sumA
+      def clientProgram[F[_]](
+          implicit client: Resource[F, service.ProtoRPCService.Client[F]],
+          B: Bracket[F, Throwable]): F[Int] =
+        client.use(_.sumA)
 
       clientProgram[ConcurrentMonad].unsafeRunSync() shouldBe 3000
     }

--- a/modules/server/src/test/scala/protocol/Utils.scala
+++ b/modules/server/src/test/scala/protocol/Utils.scala
@@ -518,19 +518,19 @@ object Utils extends CommonUtils {
     // Client Runtime Configuration //
     //////////////////////////////////
 
-    implicit val protoRPCServiceClient: ProtoRPCService.Client[ConcurrentMonad] =
+    implicit val protoRPCServiceClient: ConcurrentMonad[ProtoRPCService.Client[ConcurrentMonad]] =
       ProtoRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val avroRPCServiceClient: AvroRPCService.Client[ConcurrentMonad] =
+    implicit val avroRPCServiceClient: ConcurrentMonad[AvroRPCService.Client[ConcurrentMonad]] =
       AvroRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val awsRPCServiceClient: AvroWithSchemaRPCService.Client[ConcurrentMonad] =
+    implicit val awsRPCServiceClient: ConcurrentMonad[AvroWithSchemaRPCService.Client[ConcurrentMonad]] =
       AvroWithSchemaRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val compressedprotoRPCServiceClient: CompressedProtoRPCService.Client[
-      ConcurrentMonad] =
+    implicit val compressedprotoRPCServiceClient: ConcurrentMonad[CompressedProtoRPCService.Client[
+      ConcurrentMonad]] =
       CompressedProtoRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val compressedavroRPCServiceClient: CompressedAvroRPCService.Client[ConcurrentMonad] =
+    implicit val compressedavroRPCServiceClient: ConcurrentMonad[CompressedAvroRPCService.Client[ConcurrentMonad]] =
       CompressedAvroRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val compressedawsRPCServiceClient: CompressedAvroWithSchemaRPCService.Client[
-      ConcurrentMonad] =
+    implicit val compressedawsRPCServiceClient: ConcurrentMonad[CompressedAvroWithSchemaRPCService.Client[
+      ConcurrentMonad]] =
       CompressedAvroWithSchemaRPCService.client[ConcurrentMonad](createChannelFor)
 
   }

--- a/modules/server/src/test/scala/protocol/Utils.scala
+++ b/modules/server/src/test/scala/protocol/Utils.scala
@@ -18,7 +18,7 @@ package mu.rpc
 package protocol
 
 import cats.MonadError
-import cats.effect.Async
+import cats.effect.{Async, Resource}
 import cats.syntax.applicative._
 import mu.rpc.common._
 import io.grpc.Status
@@ -265,221 +265,221 @@ object Utils extends CommonUtils {
 
       class MuRPCServiceClientHandler[F[_]: Async](
           implicit
-          proto: ProtoRPCService.Client[F],
-          aws: AvroWithSchemaRPCService.Client[F],
-          avro: AvroRPCService.Client[F],
+          proto: Resource[F, ProtoRPCService.Client[F]],
+          aws: Resource[F, AvroWithSchemaRPCService.Client[F]],
+          avro: Resource[F, AvroRPCService.Client[F]],
           M: MonadError[F, Throwable])
           extends MyRPCClient[F] {
 
         import scala.concurrent.ExecutionContext.Implicits.global
 
         override def notAllowed(b: Boolean): F[C] =
-          proto.notAllowed(b)
+          proto.use(_.notAllowed(b))
 
         override def empty: F[Empty.type] =
-          proto.empty(protocol.Empty)
+          proto.use(_.empty(protocol.Empty))
 
         override def emptyParam(a: A): F[Empty.type] =
-          proto.emptyParam(a)
+          proto.use(_.emptyParam(a))
 
         override def emptyParamResponse: F[A] =
-          proto.emptyParamResponse(protocol.Empty)
+          proto.use(_.emptyParamResponse(protocol.Empty))
 
         override def emptyAvro: F[Empty.type] =
-          avro.emptyAvro(protocol.Empty)
+          avro.use(_.emptyAvro(protocol.Empty))
 
         override def emptyAvroWithSchema: F[Empty.type] =
-          aws.emptyAvroWithSchema(protocol.Empty)
+          aws.use(_.emptyAvroWithSchema(protocol.Empty))
 
         override def emptyAvroParam(a: A): F[Empty.type] =
-          avro.emptyAvroParam(a)
+          avro.use(_.emptyAvroParam(a))
 
         override def emptyAvroWithSchemaParam(a: A): F[Empty.type] =
-          aws.emptyAvroWithSchemaParam(a)
+          aws.use(_.emptyAvroWithSchemaParam(a))
 
         override def emptyAvroParamResponse: F[A] =
-          avro.emptyAvroParamResponse(protocol.Empty)
+          avro.use(_.emptyAvroParamResponse(protocol.Empty))
 
         override def emptyAvroWithSchemaParamResponse: F[A] =
-          aws.emptyAvroWithSchemaParamResponse(protocol.Empty)
+          aws.use(_.emptyAvroWithSchemaParamResponse(protocol.Empty))
 
         override def u(x: Int, y: Int): F[C] =
-          avro.unary(A(x, y))
+          avro.use(_.unary(A(x, y)))
 
         override def uws(x: Int, y: Int): F[C] =
-          aws.unaryWithSchema(A(x, y))
+          aws.use(_.unaryWithSchema(A(x, y)))
 
         override def uwe(a: A, err: String): F[C] =
-          avro.unaryWithError(E(a, err))
+          avro.use(_.unaryWithError(E(a, err)))
 
         override def ss(a: Int, b: Int): F[List[C]] =
           proto
-            .serverStreaming(B(A(a, a), A(b, b)))
-            .zipWithIndex
-            .map {
-              case (c, i) =>
-                debug(s"[CLIENT] Result #$i: $c")
-                c
-            }
-            .toListL
-            .toAsync[F]
+            .use(
+              _.serverStreaming(B(A(a, a), A(b, b))).zipWithIndex
+                .map {
+                  case (c, i) =>
+                    debug(s"[CLIENT] Result #$i: $c")
+                    c
+                }
+                .toListL
+                .toAsync[F])
 
         override def ss192(a: Int, b: Int): F[List[C]] =
           proto
-            .serverStreaming(B(A(a, a), A(b, b)))
-            .toListL
-            .toAsync[F]
+            .use(
+              _.serverStreaming(B(A(a, a), A(b, b))).toListL
+                .toAsync[F])
 
         override def sswe(a: A, err: String): F[List[C]] =
           proto
-            .serverStreamingWithError(E(a, err))
-            .zipWithIndex
-            .map {
-              case (c, i) =>
-                debug(s"[CLIENT] Result #$i: $c")
-                c
-            }
-            .toListL
-            .toAsync[F]
+            .use(
+              _.serverStreamingWithError(E(a, err)).zipWithIndex
+                .map {
+                  case (c, i) =>
+                    debug(s"[CLIENT] Result #$i: $c")
+                    c
+                }
+                .toListL
+                .toAsync[F])
 
         override def cs(cList: List[C], bar: Int): F[D] =
-          proto.clientStreaming(Observable.fromIterable(cList.map(c => c.a)))
+          proto.use(_.clientStreaming(Observable.fromIterable(cList.map(c => c.a))))
 
         import cats.syntax.functor._
         override def bs(eList: List[E]): F[E] =
           avro
-            .biStreaming(Observable.fromIterable(eList))
-            .zipWithIndex
-            .map {
-              case (c, i) =>
-                debug(s"[CLIENT] Result #$i: $c")
-                c
-            }
-            .toListL
-            .toAsync[F]
+            .use(
+              _.biStreaming(Observable.fromIterable(eList)).zipWithIndex
+                .map {
+                  case (c, i) =>
+                    debug(s"[CLIENT] Result #$i: $c")
+                    c
+                }
+                .toListL
+                .toAsync[F])
             .map(_.head)
 
         override def bsws(eList: List[E]): F[E] =
           aws
-            .biStreamingWithSchema(Observable.fromIterable(eList))
-            .zipWithIndex
-            .map {
-              case (c, i) =>
-                debug(s"[CLIENT] Result #$i: $c")
-                c
-            }
-            .toListL
-            .toAsync[F]
+            .use(
+              _.biStreamingWithSchema(Observable.fromIterable(eList)).zipWithIndex
+                .map {
+                  case (c, i) =>
+                    debug(s"[CLIENT] Result #$i: $c")
+                    c
+                }
+                .toListL
+                .toAsync[F])
             .map(_.head)
 
       }
 
       class MuRPCServiceClientCompressedHandler[F[_]: Async](
-          implicit proto: CompressedProtoRPCService.Client[F],
-          aws: CompressedAvroWithSchemaRPCService.Client[F],
-          avro: CompressedAvroRPCService.Client[F],
+          implicit proto: Resource[F, CompressedProtoRPCService.Client[F]],
+          aws: Resource[F, CompressedAvroWithSchemaRPCService.Client[F]],
+          avro: Resource[F, CompressedAvroRPCService.Client[F]],
           M: MonadError[F, Throwable])
           extends MyRPCClient[F] {
 
         import scala.concurrent.ExecutionContext.Implicits.global
 
         override def notAllowed(b: Boolean): F[C] =
-          proto.notAllowedCompressed(b)
+          proto.use(_.notAllowedCompressed(b))
 
         override def empty: F[Empty.type] =
-          proto.emptyCompressed(protocol.Empty)
+          proto.use(_.emptyCompressed(protocol.Empty))
 
         override def emptyParam(a: A): F[Empty.type] =
-          proto.emptyParamCompressed(a)
+          proto.use(_.emptyParamCompressed(a))
 
         override def emptyParamResponse: F[A] =
-          proto.emptyParamResponseCompressed(protocol.Empty)
+          proto.use(_.emptyParamResponseCompressed(protocol.Empty))
 
         override def emptyAvro: F[Empty.type] =
-          avro.emptyAvroCompressed(protocol.Empty)
+          avro.use(_.emptyAvroCompressed(protocol.Empty))
 
         override def emptyAvroWithSchema: F[Empty.type] =
-          aws.emptyAvroWithSchemaCompressed(protocol.Empty)
+          aws.use(_.emptyAvroWithSchemaCompressed(protocol.Empty))
 
         override def emptyAvroParam(a: A): F[Empty.type] =
-          avro.emptyAvroParamCompressed(a)
+          avro.use(_.emptyAvroParamCompressed(a))
 
         override def emptyAvroWithSchemaParam(a: A): F[Empty.type] =
-          aws.emptyAvroWithSchemaParamCompressed(a)
+          aws.use(_.emptyAvroWithSchemaParamCompressed(a))
 
         override def emptyAvroParamResponse: F[A] =
-          avro.emptyAvroParamResponseCompressed(protocol.Empty)
+          avro.use(_.emptyAvroParamResponseCompressed(protocol.Empty))
 
         override def emptyAvroWithSchemaParamResponse: F[A] =
-          aws.emptyAvroWithSchemaParamResponseCompressed(protocol.Empty)
+          aws.use(_.emptyAvroWithSchemaParamResponseCompressed(protocol.Empty))
 
         override def u(x: Int, y: Int): F[C] =
-          avro.unaryCompressed(A(x, y))
+          avro.use(_.unaryCompressed(A(x, y)))
 
         override def uwe(a: A, err: String): F[C] =
-          avro.unaryCompressedWithError(E(a, err))
+          avro.use(_.unaryCompressedWithError(E(a, err)))
 
         override def uws(x: Int, y: Int): F[C] =
-          aws.unaryCompressedWithSchema(A(x, y))
+          aws.use(_.unaryCompressedWithSchema(A(x, y)))
 
         override def ss(a: Int, b: Int): F[List[C]] =
           proto
-            .serverStreamingCompressed(B(A(a, a), A(b, b)))
-            .zipWithIndex
-            .map {
-              case (c, i) =>
-                debug(s"[CLIENT] Result #$i: $c")
-                c
-            }
-            .toListL
-            .toAsync[F]
+            .use(
+              _.serverStreamingCompressed(B(A(a, a), A(b, b))).zipWithIndex
+                .map {
+                  case (c, i) =>
+                    debug(s"[CLIENT] Result #$i: $c")
+                    c
+                }
+                .toListL
+                .toAsync[F])
 
         override def ss192(a: Int, b: Int): F[List[C]] =
           proto
-            .serverStreamingCompressed(B(A(a, a), A(b, b)))
-            .toListL
-            .toAsync[F]
+            .use(
+              _.serverStreamingCompressed(B(A(a, a), A(b, b))).toListL
+                .toAsync[F])
 
         override def sswe(a: A, err: String): F[List[C]] =
           proto
-            .serverStreamingCompressedWithError(E(a, err))
-            .zipWithIndex
-            .map {
-              case (c, i) =>
-                debug(s"[CLIENT] Result #$i: $c")
-                c
-            }
-            .toListL
-            .toAsync[F]
+            .use(
+              _.serverStreamingCompressedWithError(E(a, err)).zipWithIndex
+                .map {
+                  case (c, i) =>
+                    debug(s"[CLIENT] Result #$i: $c")
+                    c
+                }
+                .toListL
+                .toAsync[F])
 
         override def cs(cList: List[C], bar: Int): F[D] =
-          proto.clientStreamingCompressed(Observable.fromIterable(cList.map(c => c.a)))
+          proto.use(_.clientStreamingCompressed(Observable.fromIterable(cList.map(c => c.a))))
 
         import cats.syntax.functor._
         override def bs(eList: List[E]): F[E] =
           avro
-            .biStreamingCompressed(Observable.fromIterable(eList))
-            .zipWithIndex
-            .map {
-              case (c, i) =>
-                debug(s"[CLIENT] Result #$i: $c")
-                c
-            }
-            .toListL
-            .toAsync[F]
+            .use(
+              _.biStreamingCompressed(Observable.fromIterable(eList)).zipWithIndex
+                .map {
+                  case (c, i) =>
+                    debug(s"[CLIENT] Result #$i: $c")
+                    c
+                }
+                .toListL
+                .toAsync[F])
             .map(_.head)
 
         override def bsws(eList: List[E]): F[E] =
           aws
-            .biStreamingCompressedWithSchema(Observable.fromIterable(eList))
-            .zipWithIndex
-            .map {
-              case (c, i) =>
-                debug(s"[CLIENT] Result #$i: $c")
-                c
-            }
-            .toListL
-            .toAsync[F]
+            .use(
+              _.biStreamingCompressedWithSchema(Observable.fromIterable(eList)).zipWithIndex
+                .map {
+                  case (c, i) =>
+                    debug(s"[CLIENT] Result #$i: $c")
+                    c
+                }
+                .toListL
+                .toAsync[F])
             .map(_.head)
 
       }
@@ -518,19 +518,29 @@ object Utils extends CommonUtils {
     // Client Runtime Configuration //
     //////////////////////////////////
 
-    implicit val protoRPCServiceClient: ConcurrentMonad[ProtoRPCService.Client[ConcurrentMonad]] =
+    implicit val protoRPCServiceClient: Resource[
+      ConcurrentMonad,
+      ProtoRPCService.Client[ConcurrentMonad]] =
       ProtoRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val avroRPCServiceClient: ConcurrentMonad[AvroRPCService.Client[ConcurrentMonad]] =
+    implicit val avroRPCServiceClient: Resource[
+      ConcurrentMonad,
+      AvroRPCService.Client[ConcurrentMonad]] =
       AvroRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val awsRPCServiceClient: ConcurrentMonad[AvroWithSchemaRPCService.Client[ConcurrentMonad]] =
+    implicit val awsRPCServiceClient: Resource[
+      ConcurrentMonad,
+      AvroWithSchemaRPCService.Client[ConcurrentMonad]] =
       AvroWithSchemaRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val compressedprotoRPCServiceClient: ConcurrentMonad[CompressedProtoRPCService.Client[
-      ConcurrentMonad]] =
+    implicit val compressedprotoRPCServiceClient: Resource[
+      ConcurrentMonad,
+      CompressedProtoRPCService.Client[ConcurrentMonad]] =
       CompressedProtoRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val compressedavroRPCServiceClient: ConcurrentMonad[CompressedAvroRPCService.Client[ConcurrentMonad]] =
+    implicit val compressedavroRPCServiceClient: Resource[
+      ConcurrentMonad,
+      CompressedAvroRPCService.Client[ConcurrentMonad]] =
       CompressedAvroRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val compressedawsRPCServiceClient: ConcurrentMonad[CompressedAvroWithSchemaRPCService.Client[
-      ConcurrentMonad]] =
+    implicit val compressedawsRPCServiceClient: Resource[
+      ConcurrentMonad,
+      CompressedAvroWithSchemaRPCService.Client[ConcurrentMonad]] =
       CompressedAvroWithSchemaRPCService.client[ConcurrentMonad](createChannelFor)
 
   }

--- a/modules/ssl/src/test/scala/RPCTests.scala
+++ b/modules/ssl/src/test/scala/RPCTests.scala
@@ -18,7 +18,6 @@ package mu.rpc
 package ssl
 
 import cats.effect.{IO, Resource}
-import cats.syntax.either._
 import mu.rpc.client.OverrideAuthority
 import mu.rpc.client.netty.{
   NettyChannelInterpreter,
@@ -54,7 +53,6 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
         S.isShutdown
 
       check[ConcurrentMonad].unsafeRunSync() shouldBe false
-
     }
 
     "allow to get the port where it's running" in {
@@ -63,7 +61,6 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
         S.getPort
 
       check[ConcurrentMonad].unsafeRunSync() shouldBe SC.port
-
     }
 
   }
@@ -74,11 +71,11 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
       val channelInterpreter: NettyChannelInterpreter = new NettyChannelInterpreter(
         createChannelFor,
+        List(OverrideAuthority(TestUtils.TEST_SERVER_HOST)),
         List(
-          OverrideAuthority(TestUtils.TEST_SERVER_HOST).asLeft,
-          NettyUsePlaintext().asRight,
-          NettyNegotiationType(NegotiationType.TLS).asRight,
-          NettySslContext(clientSslContext).asRight
+          NettyUsePlaintext(),
+          NettyNegotiationType(NegotiationType.TLS),
+          NettySslContext(clientSslContext)
         )
       )
 
@@ -98,10 +95,10 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
       val channelInterpreter: NettyChannelInterpreter = new NettyChannelInterpreter(
         createChannelFor,
+        List(OverrideAuthority(TestUtils.TEST_SERVER_HOST)),
         List(
-          OverrideAuthority(TestUtils.TEST_SERVER_HOST).asLeft,
-          NettyUsePlaintext().asRight,
-          NettyNegotiationType(NegotiationType.TLS).asRight
+          NettyUsePlaintext(),
+          NettyNegotiationType(NegotiationType.TLS)
         )
       )
 
@@ -124,10 +121,10 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
       val channelInterpreter: NettyChannelInterpreter = new NettyChannelInterpreter(
         createChannelFor,
+        List(OverrideAuthority(TestUtils.TEST_SERVER_HOST)),
         List(
-          OverrideAuthority(TestUtils.TEST_SERVER_HOST).asLeft,
-          NettyUsePlaintext().asRight,
-          NettySslContext(clientSslContext).asRight
+          NettyUsePlaintext(),
+          NettySslContext(clientSslContext)
         )
       )
 


### PR DESCRIPTION
This pull request brings the ability to create RPC clients referentially transparent. To do that, we instantiate a client as `cats.effect.Resource` that effectfully allocates and releases a resource.

Fixes #305 