### PR TITLE
Makes the client extends the service

### DIFF
--- a/benchmarks/shared/src/main/scala/AvroBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/AvroBenchmark.scala
@@ -36,7 +36,7 @@ class AvroBenchmark extends Runtime {
 
   implicit val handler: AvroHandler[IO]    = new AvroHandler[IO]
   val sc: ServerChannel                    = ServerChannel(PersonServiceAvro.bindService[IO])
-  val clientIO: Resource[IO, PersonServiceAvro.Client[IO]] = PersonServiceAvro.clientFromChannel[IO](IO(sc.channel))
+  val clientIO: Resource[IO, PersonServiceAvro[IO]] = PersonServiceAvro.clientFromChannel[IO](IO(sc.channel))
 
   @TearDown
   def shutdown(): Unit = IO(sc.shutdown()).void.unsafeRunSync()

--- a/benchmarks/shared/src/main/scala/AvroWithSchemaBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/AvroWithSchemaBenchmark.scala
@@ -36,7 +36,7 @@ class AvroWithSchemaBenchmark extends Runtime {
 
   implicit val handler: AvroWithSchemaHandler[IO] = new AvroWithSchemaHandler[IO]
   val sc: ServerChannel                           = ServerChannel(PersonServiceAvroWithSchema.bindService[IO])
-  val clientIO: Resource[IO, PersonServiceAvroWithSchema.Client[IO]] =
+  val clientIO: Resource[IO, PersonServiceAvroWithSchema[IO]] =
     PersonServiceAvroWithSchema.clientFromChannel[IO](IO(sc.channel))
 
   @TearDown

--- a/benchmarks/shared/src/main/scala/ProtoBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/ProtoBenchmark.scala
@@ -36,7 +36,7 @@ class ProtoBenchmark extends Runtime {
 
   implicit val handler: ProtoHandler[IO] = new ProtoHandler[IO]
   val sc: ServerChannel                  = ServerChannel(PersonServicePB.bindService[IO])
-  val clientIO: Resource[IO, PersonServicePB.Client[IO]] = PersonServicePB.clientFromChannel[IO](IO(sc.channel))
+  val clientIO: Resource[IO, PersonServicePB[IO]] = PersonServicePB.clientFromChannel[IO](IO(sc.channel))
 
   @TearDown
   def shutdown(): Unit = IO(sc.shutdown()).void.unsafeRunSync()

--- a/docs/src/main/tut/core-concepts.md
+++ b/docs/src/main/tut/core-concepts.md
@@ -244,7 +244,7 @@ trait ChannelImplicits extends CommonRuntime {
   val channelFor: ChannelFor =
     ConfigForAddress[IO]("rpc.host", "rpc.port").unsafeRunSync
 
-  implicit val serviceClient: Resource[IO, Greeter.Client[IO]] =
+  implicit val serviceClient: Resource[IO, Greeter[IO]] =
     Greeter.client[IO](channelFor, options = CallOptions.DEFAULT.withCompression("gzip"))
 }
 

--- a/docs/src/main/tut/metrics-reporting.md
+++ b/docs/src/main/tut/metrics-reporting.md
@@ -104,7 +104,7 @@ object InterceptingClientCalls extends CommonRuntime {
   val channelFor: ChannelFor =
     ConfigForAddress[IO]("rpc.host", "rpc.port").unsafeRunSync
 
-  implicit val serviceClient: Resource[IO, Greeter.Client[IO]] =
+  implicit val serviceClient: Resource[IO, Greeter[IO]] =
     Greeter.client[IO](
       channelFor = channelFor,
       channelConfigList = List(

--- a/docs/src/main/tut/patterns.md
+++ b/docs/src/main/tut/patterns.md
@@ -285,7 +285,7 @@ object gclient {
     val channelFor: ChannelFor =
       ConfigForAddress[IO]("rpc.host", "rpc.port").unsafeRunSync
 
-    implicit val serviceClient: Resource[IO, Greeter.Client[IO]] =
+    implicit val serviceClient: Resource[IO, Greeter[IO]] =
       Greeter.client[IO](channelFor)
   }
 

--- a/docs/src/main/tut/ssl-tls.md
+++ b/docs/src/main/tut/ssl-tls.md
@@ -176,7 +176,7 @@ object MainApp extends CommonRuntime {
     )
   )
 
-  val muRPCServiceClient: Resource[IO, Greeter.Client[IO]] =
+  val muRPCServiceClient: Resource[IO, Greeter[IO]] =
     Greeter.clientFromChannel[IO](IO(channelInterpreter.build))
 
 }

--- a/modules/client-netty/src/main/scala/netty.scala
+++ b/modules/client-netty/src/main/scala/netty.scala
@@ -52,7 +52,7 @@ package object netty {
     case NettyEventLoopGroup(eventLoopGroup) => mcb.eventLoopGroup(eventLoopGroup)
     case NettySslContext(sslContext)         => mcb.sslContext(sslContext)
     case NettyFlowControlWindow(fcw)         => mcb.flowControlWindow(fcw)
-    case NettyMaxHeaderListSize(mhls)        => mcb.maxHeaderListSize(mhls)
+    case NettyMaxHeaderListSize(mhls)        => mcb.maxInboundMetadataSize(mhls)
     case NettyUsePlaintext()                 => mcb.usePlaintext()
     case NettyUseTransportSecurity           => mcb.useTransportSecurity()
     case NettyKeepAliveTime(kat, tu)         => mcb.keepAliveTime(kat, tu)

--- a/modules/examples/routeguide/client/src/main/scala-io/implicitsio.scala
+++ b/modules/examples/routeguide/client/src/main/scala-io/implicitsio.scala
@@ -24,7 +24,7 @@ import example.routeguide.client.runtime._
 
 trait ClientIOImplicits extends RouteGuide with ClientConf {
 
-  implicit val routeGuideServiceClient: Resource[IO, RouteGuideService.Client[IO]] =
+  implicit val routeGuideServiceClient: Resource[IO, RouteGuideService[IO]] =
     RouteGuideService.client[IO](channelFor)
 
   implicit val routeGuideClientHandler: RouteGuideClientHandler[IO] =

--- a/modules/examples/routeguide/client/src/main/scala-task/implicitstask.scala
+++ b/modules/examples/routeguide/client/src/main/scala-task/implicitstask.scala
@@ -25,7 +25,7 @@ import monix.eval.Task
 
 trait ClientTaskImplicits extends RouteGuide with ClientConf {
 
-  implicit val routeGuideServiceClient: Resource[Task, RouteGuideService.Client[Task]] =
+  implicit val routeGuideServiceClient: Resource[Task, RouteGuideService[Task]] =
     RouteGuideService.client[Task](channelFor)
 
   implicit val routeGuideClientHandler: RouteGuideClientHandler[Task] =

--- a/modules/examples/routeguide/client/src/main/scala/handlers/RouteGuideClientHandler.scala
+++ b/modules/examples/routeguide/client/src/main/scala/handlers/RouteGuideClientHandler.scala
@@ -30,7 +30,7 @@ import example.routeguide.common.Utils._
 import scala.concurrent.duration._
 
 class RouteGuideClientHandler[F[_]: ConcurrentEffect](
-    implicit client: Resource[F, RouteGuideService.Client[F]],
+    implicit client: Resource[F, RouteGuideService[F]],
     E: Effect[Task])
     extends RouteGuideClient[F] {
 

--- a/modules/examples/todolist/client/src/main/scala/handlers/PingPongClientHandler.scala
+++ b/modules/examples/todolist/client/src/main/scala/handlers/PingPongClientHandler.scala
@@ -24,7 +24,7 @@ import examples.todolist.protocol.Protocols.PingPongService
 import mu.rpc.protocol.Empty
 import org.log4s._
 
-class PingPongClientHandler[F[_]: Sync](client: Resource[F, PingPongService.Client[F]])
+class PingPongClientHandler[F[_]: Sync](client: Resource[F, PingPongService[F]])
     extends PingPongClient[F] {
 
   val logger: Logger = getLogger

--- a/modules/examples/todolist/client/src/main/scala/handlers/TagClientHandler.scala
+++ b/modules/examples/todolist/client/src/main/scala/handlers/TagClientHandler.scala
@@ -26,8 +26,7 @@ import examples.todolist.protocol.Protocols._
 import mu.rpc.protocol.Empty
 import freestyle.tagless.logging.LoggingM
 
-class TagClientHandler[F[_]: Sync](client: Resource[F, TagRpcService.Client[F]])(
-    implicit log: LoggingM[F])
+class TagClientHandler[F[_]: Sync](client: Resource[F, TagRpcService[F]])(implicit log: LoggingM[F])
     extends TagClient[F] {
 
   override def reset(): F[Int] =

--- a/modules/examples/todolist/client/src/main/scala/handlers/TodoItemClientHandler.scala
+++ b/modules/examples/todolist/client/src/main/scala/handlers/TodoItemClientHandler.scala
@@ -26,7 +26,7 @@ import examples.todolist.protocol.Protocols._
 import mu.rpc.protocol.Empty
 import freestyle.tagless.logging.LoggingM
 
-class TodoItemClientHandler[F[_]: Sync](client: Resource[F, TodoItemRpcService.Client[F]])(
+class TodoItemClientHandler[F[_]: Sync](client: Resource[F, TodoItemRpcService[F]])(
     implicit log: LoggingM[F])
     extends TodoItemClient[F] {
 

--- a/modules/examples/todolist/client/src/main/scala/handlers/TodoListClientHandler.scala
+++ b/modules/examples/todolist/client/src/main/scala/handlers/TodoListClientHandler.scala
@@ -26,7 +26,7 @@ import examples.todolist.protocol._
 import mu.rpc.protocol.Empty
 import freestyle.tagless.logging.LoggingM
 
-class TodoListClientHandler[F[_]: Sync](client: Resource[F, TodoListRpcService.Client[F]])(
+class TodoListClientHandler[F[_]: Sync](client: Resource[F, TodoListRpcService[F]])(
     implicit log: LoggingM[F])
     extends TodoListClient[F] {
 

--- a/modules/examples/todolist/client/src/main/scala/implicits.scala
+++ b/modules/examples/todolist/client/src/main/scala/implicits.scala
@@ -19,8 +19,8 @@ package examples.todolist.client
 import cats.effect.{ContextShift, IO, Resource, Timer}
 import examples.todolist.client.handlers._
 import examples.todolist.protocol.Protocols._
-import freestyle.tagless.loggingJVM.log4s.implicits._
 import examples.todolist.runtime.CommonRuntime
+import freestyle.tagless.loggingJVM.log4s.implicits._
 import mu.rpc.ChannelFor
 import mu.rpc.client.config.ConfigForAddress
 
@@ -32,25 +32,25 @@ trait ClientImplicits extends CommonRuntime {
   val channelFor: ChannelFor =
     ConfigForAddress[IO]("rpc.client.host", "rpc.client.port").unsafeRunSync()
 
-  val pingPongServiceClient: Resource[IO, PingPongService.Client[IO]] =
+  val pingPongServiceClient: Resource[IO, PingPongService[IO]] =
     PingPongService.client[IO](channelFor)
 
   implicit val pingPongClientHandler: PingPongClientHandler[IO] =
     new PingPongClientHandler[IO](pingPongServiceClient)
 
-  val tagRpcServiceClient: Resource[IO, TagRpcService.Client[IO]] =
+  val tagRpcServiceClient: Resource[IO, TagRpcService[IO]] =
     TagRpcService.client[IO](channelFor)
 
   implicit val tagClientHandler: TagClientHandler[IO] =
     new TagClientHandler[IO](tagRpcServiceClient)
 
-  val todoListRpcServiceClient: Resource[IO, TodoListRpcService.Client[IO]] =
+  val todoListRpcServiceClient: Resource[IO, TodoListRpcService[IO]] =
     TodoListRpcService.client[IO](channelFor)
 
   implicit val todoListClientHandler: TodoListClientHandler[IO] =
     new TodoListClientHandler[IO](todoListRpcServiceClient)
 
-  val todoItemRpcServiceClient: Resource[IO, TodoItemRpcService.Client[IO]] =
+  val todoItemRpcServiceClient: Resource[IO, TodoItemRpcService[IO]] =
     TodoItemRpcService.client[IO](channelFor)
 
   implicit val todoItemClientHandler: TodoItemClientHandler[IO] =

--- a/modules/idlgen/core/src/main/scala/SrcGenApplication.scala
+++ b/modules/idlgen/core/src/main/scala/SrcGenApplication.scala
@@ -25,6 +25,9 @@ object SrcGenApplication {
       bigDecimalTypeGen: BigDecimalTypeGen = ScalaBigDecimalTaggedGen): GeneratorApplication[
     AvroSrcGenerator] =
     new GeneratorApplication(AvroSrcGenerator(marshallersImports, bigDecimalTypeGen)) {
-      def main(args: Array[String]): Unit = generateFrom(args)
+      def main(args: Array[String]): Unit = {
+        generateFrom(args)
+        (): Unit
+      }
     }
 }

--- a/modules/internal/src/main/scala/service.scala
+++ b/modules/internal/src/main/scala/service.scala
@@ -190,7 +190,7 @@ object serviceImpl {
         )(implicit
           F: _root_.cats.effect.ConcurrentEffect[$F],
           EC: _root_.scala.concurrent.ExecutionContext
-        ) extends _root_.io.grpc.stub.AbstractStub[$Client[$F]](channel, options) {
+        ) extends _root_.io.grpc.stub.AbstractStub[$Client[$F]](channel, options) with $serviceName[$F] {
           override def build(channel: _root_.io.grpc.Channel, options: _root_.io.grpc.CallOptions): $Client[$F] =
               new $Client[$F](channel, options)
 
@@ -208,12 +208,12 @@ object serviceImpl {
           )(implicit
           F: _root_.cats.effect.ConcurrentEffect[$F],
           EC: _root_.scala.concurrent.ExecutionContext
-        ): _root_.cats.effect.Resource[F, $Client[$F]] =
+        ): _root_.cats.effect.Resource[F, $serviceName[$F]] =
           _root_.cats.effect.Resource.make {
             val managedChannelInterpreter = new _root_.mu.rpc.client.ManagedChannelInterpreter[$F](channelFor, channelConfigList)
             managedChannelInterpreter.build(channelFor, channelConfigList)
           }(channel => F.void(F.delay(channel.shutdown()))).flatMap(ch =>
-          _root_.cats.effect.Resource.make(F.delay(new $Client[$F](ch, options)))(_ => F.unit))
+          _root_.cats.effect.Resource.make[F, $serviceName[$F]](F.delay(new $Client[$F](ch, options)))(_ => F.unit))
         """.supressWarts("DefaultArguments")
 
       val clientFromChannel: DefDef =
@@ -224,9 +224,9 @@ object serviceImpl {
         )(implicit
           F: _root_.cats.effect.ConcurrentEffect[$F],
           EC: _root_.scala.concurrent.ExecutionContext
-        ): _root_.cats.effect.Resource[F, $Client[$F]] = _root_.cats.effect.Resource.make(channel)(channel =>
+        ): _root_.cats.effect.Resource[F, $serviceName[$F]] = _root_.cats.effect.Resource.make(channel)(channel =>
         F.void(F.delay(channel.shutdown()))).flatMap(ch =>
-        _root_.cats.effect.Resource.make(F.delay(new $Client[$F](ch, options)))(_ => F.unit))
+        _root_.cats.effect.Resource.make[F, $serviceName[$F]](F.delay(new $Client[$F](ch, options)))(_ => F.unit))
         """.supressWarts("DefaultArguments")
 
       val unsafeClient: DefDef =
@@ -239,7 +239,7 @@ object serviceImpl {
           )(implicit
           F: _root_.cats.effect.ConcurrentEffect[$F],
           EC: _root_.scala.concurrent.ExecutionContext
-        ): $Client[$F] = {
+        ): $serviceName[$F] = {
           val managedChannelInterpreter =
             new _root_.mu.rpc.client.ManagedChannelInterpreter[$F](channelFor, channelConfigList)
           new $Client[$F](managedChannelInterpreter.unsafeBuild(channelFor, channelConfigList), options)
@@ -253,7 +253,7 @@ object serviceImpl {
         )(implicit
           F: _root_.cats.effect.ConcurrentEffect[$F],
           EC: _root_.scala.concurrent.ExecutionContext
-        ): $Client[$F] = new $Client[$F](channel, options)
+        ): $serviceName[$F] = new $Client[$F](channel, options)
         """.supressWarts("DefaultArguments")
 
       private def lit(x: Any): Literal = Literal(Constant(x.toString))

--- a/modules/prometheus/client/src/test/scala/InterceptorsRuntime.scala
+++ b/modules/prometheus/client/src/test/scala/InterceptorsRuntime.scala
@@ -59,31 +59,30 @@ case class InterceptorsRuntime(
     AddInterceptor(MonitoringClientInterceptor(configuration.withCollectorRegistry(cr)))
   )
 
-  implicit lazy val muProtoRPCServiceClient: Resource[
-    ConcurrentMonad,
-    ProtoRPCService.Client[ConcurrentMonad]] =
+  lazy val muProtoRPCServiceClient: Resource[ConcurrentMonad, ProtoRPCService[ConcurrentMonad]] =
     ProtoRPCService.client[ConcurrentMonad](
       channelFor = createChannelForPort(pickUnusedPort),
       channelConfigList = configList
     )
 
-  implicit lazy val muAvroRPCServiceClient: Resource[
-    ConcurrentMonad,
-    AvroRPCService.Client[ConcurrentMonad]] =
+  lazy val muAvroRPCServiceClient: Resource[ConcurrentMonad, AvroRPCService[ConcurrentMonad]] =
     AvroRPCService.client[ConcurrentMonad](
       channelFor = createChannelForPort(pickUnusedPort),
       channelConfigList = configList
     )
 
-  implicit lazy val muAvroWithSchemaRPCServiceClient: Resource[
+  lazy val muAvroWithSchemaRPCServiceClient: Resource[
     ConcurrentMonad,
-    AvroWithSchemaRPCService.Client[ConcurrentMonad]] =
+    AvroWithSchemaRPCService[ConcurrentMonad]] =
     AvroWithSchemaRPCService.client[ConcurrentMonad](
       channelFor = createChannelForPort(pickUnusedPort),
       channelConfigList = configList
     )
 
   implicit lazy val muRPCServiceClientHandler: MuRPCServiceClientHandler[ConcurrentMonad] =
-    new MuRPCServiceClientHandler[ConcurrentMonad]
+    new MuRPCServiceClientHandler[ConcurrentMonad](
+      muProtoRPCServiceClient,
+      muAvroRPCServiceClient,
+      muAvroWithSchemaRPCServiceClient)
 
 }

--- a/modules/prometheus/server/src/test/scala/InterceptorsRuntime.scala
+++ b/modules/prometheus/server/src/test/scala/InterceptorsRuntime.scala
@@ -61,28 +61,27 @@ case class InterceptorsRuntime(
   // Client Runtime Configuration //
   //////////////////////////////////
 
-  implicit lazy val muProtoRPCServiceClient: Resource[
-    ConcurrentMonad,
-    ProtoRPCService.Client[ConcurrentMonad]] =
+  lazy val muProtoRPCServiceClient: Resource[ConcurrentMonad, ProtoRPCService[ConcurrentMonad]] =
     ProtoRPCService.client[ConcurrentMonad](
       channelFor = createChannelForPort(pickUnusedPort)
     )
 
-  implicit lazy val muAvroRPCServiceClient: Resource[
-    ConcurrentMonad,
-    AvroRPCService.Client[ConcurrentMonad]] =
+  lazy val muAvroRPCServiceClient: Resource[ConcurrentMonad, AvroRPCService[ConcurrentMonad]] =
     AvroRPCService.client[ConcurrentMonad](
       channelFor = createChannelForPort(pickUnusedPort)
     )
 
-  implicit lazy val muAvroWithSchemaRPCServiceClient: Resource[
+  lazy val muAvroWithSchemaRPCServiceClient: Resource[
     ConcurrentMonad,
-    AvroWithSchemaRPCService.Client[ConcurrentMonad]] =
+    AvroWithSchemaRPCService[ConcurrentMonad]] =
     AvroWithSchemaRPCService.client[ConcurrentMonad](
       channelFor = createChannelForPort(pickUnusedPort)
     )
 
   implicit lazy val muRPCServiceClientHandler: MuRPCServiceClientHandler[ConcurrentMonad] =
-    new MuRPCServiceClientHandler[ConcurrentMonad]
+    new MuRPCServiceClientHandler[ConcurrentMonad](
+      muProtoRPCServiceClient,
+      muAvroRPCServiceClient,
+      muAvroWithSchemaRPCServiceClient)
 
 }

--- a/modules/server/src/test/scala/avro/RPCTests.scala
+++ b/modules/server/src/test/scala/avro/RPCTests.scala
@@ -31,7 +31,7 @@ class RPCTests extends RpcBaseTestSuite {
   import mu.rpc.avro.Utils.implicits._
 
   def runSucceedAssertion[A](ssd: ServerServiceDefinition, response: A)(
-      f: service.RPCService.Client[ConcurrentMonad] => ConcurrentMonad[A]): Assertion = {
+      f: service.RPCService[ConcurrentMonad] => ConcurrentMonad[A]): Assertion = {
     withServerChannel(ssd) { sc =>
       service.RPCService
         .clientFromChannel[ConcurrentMonad](IO(sc.channel))
@@ -41,7 +41,7 @@ class RPCTests extends RpcBaseTestSuite {
   }
 
   def runFailedAssertion[A](ssd: ServerServiceDefinition)(
-      f: service.RPCService.Client[ConcurrentMonad] => ConcurrentMonad[A]): Assertion = {
+      f: service.RPCService[ConcurrentMonad] => ConcurrentMonad[A]): Assertion = {
     withServerChannel(ssd) { sc =>
       assertThrows[io.grpc.StatusRuntimeException] {
         service.RPCService.clientFromChannel[ConcurrentMonad](IO(sc.channel)).use(f).unsafeRunSync()

--- a/modules/server/src/test/scala/avro/Utils.scala
+++ b/modules/server/src/test/scala/avro/Utils.scala
@@ -395,7 +395,7 @@ object Utils extends CommonUtils {
 
     implicit val muRPCServiceClient: Resource[
       ConcurrentMonad,
-      service.RPCService.Client[ConcurrentMonad]] =
+      service.RPCService[ConcurrentMonad]] =
       service.RPCService.client[ConcurrentMonad](createChannelFor)
 
   }

--- a/modules/server/src/test/scala/fs2/Utils.scala
+++ b/modules/server/src/test/scala/fs2/Utils.scala
@@ -167,29 +167,29 @@ object Utils extends CommonUtils {
     // Client Runtime Configuration //
     //////////////////////////////////
 
-    implicit val muProtoRPCServiceClient: Resource[
+    val muProtoRPCServiceClient: Resource[
       ConcurrentMonad,
-      ProtoRPCService.Client[ConcurrentMonad]] =
+      ProtoRPCService[ConcurrentMonad]] =
       ProtoRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val muAvroRPCServiceClient: Resource[
+    val muAvroRPCServiceClient: Resource[
       ConcurrentMonad,
-      AvroRPCService.Client[ConcurrentMonad]] =
+      AvroRPCService[ConcurrentMonad]] =
       AvroRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val muAvroWithSchemaRPCServiceClient: Resource[
+    val muAvroWithSchemaRPCServiceClient: Resource[
       ConcurrentMonad,
-      AvroWithSchemaRPCService.Client[ConcurrentMonad]] =
+      AvroWithSchemaRPCService[ConcurrentMonad]] =
       AvroWithSchemaRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val muCompressedProtoRPCServiceClient: Resource[
+    val muCompressedProtoRPCServiceClient: Resource[
       ConcurrentMonad,
-      CompressedProtoRPCService.Client[ConcurrentMonad]] =
+      CompressedProtoRPCService[ConcurrentMonad]] =
       CompressedProtoRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val muCompressedAvroRPCServiceClient: Resource[
+    val muCompressedAvroRPCServiceClient: Resource[
       ConcurrentMonad,
-      CompressedAvroRPCService.Client[ConcurrentMonad]] =
+      CompressedAvroRPCService[ConcurrentMonad]] =
       CompressedAvroRPCService.client[ConcurrentMonad](createChannelFor)
-    implicit val muCompressedAvroWithSchemaRPCServiceClient: Resource[
+    val muCompressedAvroWithSchemaRPCServiceClient: Resource[
       ConcurrentMonad,
-      CompressedAvroWithSchemaRPCService.Client[ConcurrentMonad]] =
+      CompressedAvroWithSchemaRPCService[ConcurrentMonad]] =
       CompressedAvroWithSchemaRPCService.client[ConcurrentMonad](createChannelFor)
 
   }

--- a/modules/server/src/test/scala/protocol/RPCTests.scala
+++ b/modules/server/src/test/scala/protocol/RPCTests.scala
@@ -17,7 +17,6 @@
 package mu.rpc
 package protocol
 
-import cats.effect.{Bracket, Resource}
 import cats.{Monad, MonadError}
 import cats.syntax.flatMap._
 import cats.syntax.functor._
@@ -65,7 +64,10 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
   "mu client" should {
 
     implicit val muRPCServiceClientHandler: MuRPCServiceClientHandler[ConcurrentMonad] =
-      new MuRPCServiceClientHandler[ConcurrentMonad]
+      new MuRPCServiceClientHandler[ConcurrentMonad](
+        protoRPCServiceClient,
+        avroRPCServiceClient,
+        awsRPCServiceClient)
 
     "be able to run unary services" in {
 
@@ -257,22 +259,15 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
     }
 
-    "be able to have non request methods" in {
-
-      def clientProgram[F[_]](
-          implicit client: Resource[F, service.ProtoRPCService.Client[F]],
-          B: Bracket[F, Throwable]): F[Int] =
-        client.use(_.sumA)
-
-      clientProgram[ConcurrentMonad].unsafeRunSync() shouldBe 3000
-    }
-
   }
 
   "mu client with compression" should {
 
     implicit val muRPCServiceClientHandler: MuRPCServiceClientCompressedHandler[ConcurrentMonad] =
-      new MuRPCServiceClientCompressedHandler[ConcurrentMonad]
+      new MuRPCServiceClientCompressedHandler[ConcurrentMonad](
+        compressedprotoRPCServiceClient,
+        compressedavroRPCServiceClient,
+        compressedawsRPCServiceClient)
 
     "be able to run unary services" in {
 

--- a/modules/ssl/src/test/scala/RPCTests.scala
+++ b/modules/ssl/src/test/scala/RPCTests.scala
@@ -79,11 +79,11 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
         )
       )
 
-      val avroRpcService: Resource[ConcurrentMonad, AvroRPCService.Client[ConcurrentMonad]] =
+      val avroRpcService: Resource[ConcurrentMonad, AvroRPCService[ConcurrentMonad]] =
         AvroRPCService.clientFromChannel[ConcurrentMonad](IO(channelInterpreter.build))
       val avroWithSchemaRpcService: Resource[
         ConcurrentMonad,
-        AvroWithSchemaRPCService.Client[ConcurrentMonad]] =
+        AvroWithSchemaRPCService[ConcurrentMonad]] =
         AvroWithSchemaRPCService.clientFromChannel[ConcurrentMonad](IO(channelInterpreter.build))
 
       avroRpcService.use(_.unary(a1)).unsafeRunSync() shouldBe c1
@@ -102,11 +102,11 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
         )
       )
 
-      val avroRpcService: Resource[ConcurrentMonad, AvroRPCService.Client[ConcurrentMonad]] =
+      val avroRpcService: Resource[ConcurrentMonad, AvroRPCService[ConcurrentMonad]] =
         AvroRPCService.clientFromChannel[ConcurrentMonad](IO(channelInterpreter.build))
       val avroWithSchemaRpcService: Resource[
         ConcurrentMonad,
-        AvroWithSchemaRPCService.Client[ConcurrentMonad]] =
+        AvroWithSchemaRPCService[ConcurrentMonad]] =
         AvroWithSchemaRPCService.clientFromChannel[ConcurrentMonad](IO(channelInterpreter.build))
 
       a[io.grpc.StatusRuntimeException] shouldBe thrownBy(
@@ -128,11 +128,11 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
         )
       )
 
-      val avroRpcService: Resource[ConcurrentMonad, AvroRPCService.Client[ConcurrentMonad]] =
+      val avroRpcService: Resource[ConcurrentMonad, AvroRPCService[ConcurrentMonad]] =
         AvroRPCService.clientFromChannel[ConcurrentMonad](IO(channelInterpreter.build))
       val avroWithSchemaRpcService: Resource[
         ConcurrentMonad,
-        AvroWithSchemaRPCService.Client[ConcurrentMonad]] =
+        AvroWithSchemaRPCService[ConcurrentMonad]] =
         AvroWithSchemaRPCService.clientFromChannel[ConcurrentMonad](IO(channelInterpreter.build))
 
       a[io.grpc.StatusRuntimeException] shouldBe thrownBy(


### PR DESCRIPTION
Go from this
<img width="651" alt="screenshot 2018-12-14 at 18 42 17" src="https://user-images.githubusercontent.com/720923/50021357-192a7880-ffd9-11e8-9e8c-6bc67823ecce.png">

To this
<img width="615" alt="screenshot 2018-12-14 at 18 42 26" src="https://user-images.githubusercontent.com/720923/50021362-1af43c00-ffd9-11e8-8e54-018d1a89a8c8.png">

The problems:
* We can't have nonrequest methods. Not a big deal, I haven't seen rpc services with custom methods.
* The autogenerated clients are not `AbstractStub` from the user perspective. They can always make a casting. If this can be a problem, one alternative could be this #492

Thoughts?