### PR TITLE
Improve managed channel interpreter

### DIFF
--- a/modules/client/src/main/scala/ManagedChannelInterpreter.scala
+++ b/modules/client/src/main/scala/ManagedChannelInterpreter.scala
@@ -28,7 +28,7 @@ class ManagedChannelInterpreter[F[_]](
     configList: List[ManagedChannelConfig])(implicit F: Sync[F]) {
 
   def apply[A](fa: ManagedChannelOps[F, A]): F[A] =
-    fa(new ManagedChannelInterpreter(initConfig, configList).build)
+    fa(build)
 
   def build[T <: ManagedChannelBuilder[T]]: F[ManagedChannel] = {
 
@@ -49,6 +49,6 @@ class ManagedChannelInterpreter[F[_]](
   }
 
   def unsafeBuild[T <: ManagedChannelBuilder[T]](implicit E: Effect[F]): ManagedChannel =
-    E.toIO(new ManagedChannelInterpreter(initConfig, configList).build).unsafeRunSync()
+    E.toIO(build).unsafeRunSync()
 
 }

--- a/modules/client/src/main/scala/ManagedChannelInterpreter.scala
+++ b/modules/client/src/main/scala/ManagedChannelInterpreter.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mu.rpc
+package client
+
+import cats.effect.{Effect, Sync}
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+
+import io.grpc._
+
+class ManagedChannelInterpreter[F[_]](
+      initConfig: ChannelFor,
+      configList: List[ManagedChannelConfig])(implicit F: Sync[F]) {
+
+  def apply[A](fa: ManagedChannelOps[F, A]): F[A] =
+    fa(build(initConfig, configList))
+
+    def build[T <: ManagedChannelBuilder[T]](
+        initConfig: ChannelFor,
+        configList: List[ManagedChannelConfig]): F[ManagedChannel] = {
+
+      val builder: F[T] = initConfig match {
+        case ChannelForAddress(name, port) =>
+          F.delay(ManagedChannelBuilder.forAddress(name, port).asInstanceOf[T])
+        case ChannelForTarget(target) =>
+          F.delay(ManagedChannelBuilder.forTarget(target).asInstanceOf[T])
+        case e =>
+          F.raiseError(new IllegalArgumentException(s"ManagedChannel not supported for $e"))
+      }
+
+      for {
+        b          <- builder
+        configured <- F.delay(configList.foldLeft(b)(configureChannel))
+        built      <- F.delay(configured.build())
+      } yield built
+    }
+
+    def unsafeBuild[T <: ManagedChannelBuilder[T]](
+        initConfig: ChannelFor,
+        configList: List[ManagedChannelConfig])(implicit E: Effect[F]): ManagedChannel =
+      E.toIO(build(initConfig, configList)).unsafeRunSync()
+
+  }

--- a/modules/client/src/main/scala/ManagedChannelInterpreter.scala
+++ b/modules/client/src/main/scala/ManagedChannelInterpreter.scala
@@ -23,36 +23,37 @@ import cats.syntax.functor._
 
 import io.grpc._
 
-class ManagedChannelInterpreter[F[_]](
-      initConfig: ChannelFor,
-      configList: List[ManagedChannelConfig])(implicit F: Sync[F]) {
+object ManagedChannelInterpreter {
 
-  def apply[A](fa: ManagedChannelOps[F, A]): F[A] =
+  def apply[F[_], A](
+      initConfig: ChannelFor,
+      configList: List[ManagedChannelConfig],
+      fa: ManagedChannelOps[F, A])(implicit F: Sync[F]): F[A] =
     fa(build(initConfig, configList))
 
-    def build[T <: ManagedChannelBuilder[T]](
-        initConfig: ChannelFor,
-        configList: List[ManagedChannelConfig]): F[ManagedChannel] = {
+  def build[F[_], T <: ManagedChannelBuilder[T]](
+      initConfig: ChannelFor,
+      configList: List[ManagedChannelConfig])(implicit F: Sync[F]): F[ManagedChannel] = {
 
-      val builder: F[T] = initConfig match {
-        case ChannelForAddress(name, port) =>
-          F.delay(ManagedChannelBuilder.forAddress(name, port).asInstanceOf[T])
-        case ChannelForTarget(target) =>
-          F.delay(ManagedChannelBuilder.forTarget(target).asInstanceOf[T])
-        case e =>
-          F.raiseError(new IllegalArgumentException(s"ManagedChannel not supported for $e"))
-      }
-
-      for {
-        b          <- builder
-        configured <- F.delay(configList.foldLeft(b)(configureChannel))
-        built      <- F.delay(configured.build())
-      } yield built
+    val builder: F[T] = initConfig match {
+      case ChannelForAddress(name, port) =>
+        F.delay(ManagedChannelBuilder.forAddress(name, port).asInstanceOf[T])
+      case ChannelForTarget(target) =>
+        F.delay(ManagedChannelBuilder.forTarget(target).asInstanceOf[T])
+      case e =>
+        F.raiseError(new IllegalArgumentException(s"ManagedChannel not supported for $e"))
     }
 
-    def unsafeBuild[T <: ManagedChannelBuilder[T]](
-        initConfig: ChannelFor,
-        configList: List[ManagedChannelConfig])(implicit E: Effect[F]): ManagedChannel =
-      E.toIO(build(initConfig, configList)).unsafeRunSync()
-
+    for {
+      b          <- builder
+      configured <- F.delay(configList.foldLeft(b)(configureChannel))
+      built      <- F.delay(configured.build())
+    } yield built
   }
+
+  def unsafeBuild[F[_], T <: ManagedChannelBuilder[T]](
+      initConfig: ChannelFor,
+      configList: List[ManagedChannelConfig])(implicit E: Effect[F]): ManagedChannel =
+    E.toIO(build(initConfig, configList)).unsafeRunSync()
+
+}

--- a/modules/client/src/test/scala/ManagedChannelInterpreterTests.scala
+++ b/modules/client/src/test/scala/ManagedChannelInterpreterTests.scala
@@ -37,7 +37,7 @@ abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
       val managedChannelInterpreter =
         new ManagedChannelInterpreter[IO](channelFor, channelConfigList)
 
-      val mc: ManagedChannel = managedChannelInterpreter.unsafeBuild(channelFor, channelConfigList)
+      val mc: ManagedChannel = managedChannelInterpreter.unsafeBuild
 
       mc shouldBe a[ManagedChannel]
 
@@ -53,7 +53,7 @@ abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
       val managedChannelInterpreter =
         new ManagedChannelInterpreter[IO](channelFor, channelConfigList)
 
-      val mc: ManagedChannel = managedChannelInterpreter.unsafeBuild(channelFor, channelConfigList)
+      val mc: ManagedChannel = managedChannelInterpreter.unsafeBuild
 
       mc shouldBe a[ManagedChannel]
 
@@ -84,7 +84,7 @@ abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
       val managedChannelInterpreter =
         new ManagedChannelInterpreter[IO](channelFor, channelConfigList)
 
-      val mc: ManagedChannel = managedChannelInterpreter.unsafeBuild(channelFor, channelConfigList)
+      val mc: ManagedChannel = managedChannelInterpreter.unsafeBuild
 
       mc shouldBe a[ManagedChannel]
 
@@ -98,8 +98,7 @@ abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
       val managedChannelInterpreter =
         new ManagedChannelInterpreter[IO](channelFor, Nil)
 
-      an[IllegalArgumentException] shouldBe thrownBy(
-        managedChannelInterpreter.build(channelFor, Nil).unsafeRunSync)
+      an[IllegalArgumentException] shouldBe thrownBy(managedChannelInterpreter.build.unsafeRunSync)
     }
   }
 }

--- a/modules/examples/todolist/protocol/src/main/scala/TodoItemProtocol.scala
+++ b/modules/examples/todolist/protocol/src/main/scala/TodoItemProtocol.scala
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package examples.todolist
 package protocol
 

--- a/modules/internal/src/main/scala/service.scala
+++ b/modules/internal/src/main/scala/service.scala
@@ -210,8 +210,7 @@ object serviceImpl {
           EC: _root_.scala.concurrent.ExecutionContext
         ): _root_.cats.effect.Resource[F, $serviceName[$F]] =
           _root_.cats.effect.Resource.make {
-            val managedChannelInterpreter = new _root_.mu.rpc.client.ManagedChannelInterpreter[$F](channelFor, channelConfigList)
-            managedChannelInterpreter.build(channelFor, channelConfigList)
+            new _root_.mu.rpc.client.ManagedChannelInterpreter[$F](channelFor, channelConfigList).build
           }(channel => F.void(F.delay(channel.shutdown()))).flatMap(ch =>
           _root_.cats.effect.Resource.make[F, $serviceName[$F]](F.delay(new $Client[$F](ch, options)))(_ => F.unit))
         """.supressWarts("DefaultArguments")
@@ -241,8 +240,8 @@ object serviceImpl {
           EC: _root_.scala.concurrent.ExecutionContext
         ): $serviceName[$F] = {
           val managedChannelInterpreter =
-            new _root_.mu.rpc.client.ManagedChannelInterpreter[$F](channelFor, channelConfigList)
-          new $Client[$F](managedChannelInterpreter.unsafeBuild(channelFor, channelConfigList), options)
+            new _root_.mu.rpc.client.ManagedChannelInterpreter[$F](channelFor, channelConfigList).unsafeBuild
+          new $Client[$F](managedChannelInterpreter, options)
         }""".supressWarts("DefaultArguments")
 
       val unsafeClientFromChannel: DefDef =

--- a/modules/server/src/test/scala/fs2/Utils.scala
+++ b/modules/server/src/test/scala/fs2/Utils.scala
@@ -167,13 +167,9 @@ object Utils extends CommonUtils {
     // Client Runtime Configuration //
     //////////////////////////////////
 
-    val muProtoRPCServiceClient: Resource[
-      ConcurrentMonad,
-      ProtoRPCService[ConcurrentMonad]] =
+    val muProtoRPCServiceClient: Resource[ConcurrentMonad, ProtoRPCService[ConcurrentMonad]] =
       ProtoRPCService.client[ConcurrentMonad](createChannelFor)
-    val muAvroRPCServiceClient: Resource[
-      ConcurrentMonad,
-      AvroRPCService[ConcurrentMonad]] =
+    val muAvroRPCServiceClient: Resource[ConcurrentMonad, AvroRPCService[ConcurrentMonad]] =
       AvroRPCService.client[ConcurrentMonad](createChannelFor)
     val muAvroWithSchemaRPCServiceClient: Resource[
       ConcurrentMonad,


### PR DESCRIPTION
This PR separates the `ManagedChannelInterpreter` class from the package object and removes the redundant parameters from its methods.