### PR TITLE
Fixes the avro decimal compat protocol namespace

### DIFF
--- a/modules/legacy-avro-decimal/procotol/src/main/resources/legacyAvroDecimalCompatProtocol.avdl
+++ b/modules/legacy-avro-decimal/procotol/src/main/resources/legacyAvroDecimalCompatProtocol.avdl
@@ -1,4 +1,4 @@
-@namespace("mu.rpc.protocol.legacy")
+@namespace("higherkindness.mu.rpc.protocol.legacy")
 
 protocol AvroDecimalCompat {
 


### PR DESCRIPTION
Needs to be the same as https://github.com/higherkindness/mu/blob/da0daaf3099297b62d6310e444294e46ac0bc2bd/modules/legacy-avro-decimal/model/src/main/scala/higherkindness/mu/rpc/protocol/legacy/AvroDecimalCompat.scala#L17