### PR TITLE
`bindService` as an Effect

### DIFF
--- a/benchmarks/shared/src/main/scala/higherkindness/mu/rpc/benchmarks/shared/server/ServerHandler.scala
+++ b/benchmarks/shared/src/main/scala/higherkindness/mu/rpc/benchmarks/shared/server/ServerHandler.scala
@@ -19,6 +19,8 @@ package shared
 package server
 
 import cats.effect._
+import cats.instances.list._
+import cats.syntax.traverse._
 import higherkindness.mu.rpc.benchmarks.shared.models._
 import higherkindness.mu.rpc.benchmarks.shared.protocols._
 import higherkindness.mu.rpc.protocol.Empty
@@ -58,9 +60,9 @@ trait ServerImplicits extends Runtime {
   implicit private val avroWithSchemaHandler: AvroWithSchemaHandler[IO] =
     new AvroWithSchemaHandler[IO]
 
-  implicit val grpcConfigsAvro: List[GrpcConfig] = List(
-    AddService(PersonServicePB.bindService[IO]),
-    AddService(PersonServiceAvro.bindService[IO]),
-    AddService(PersonServiceAvroWithSchema.bindService[IO])
-  )
+  implicit val grpcConfigsAvro: IO[List[GrpcConfig]] = List(
+    PersonServicePB.bindService[IO].map(AddService),
+    PersonServiceAvro.bindService[IO].map(AddService),
+    PersonServiceAvroWithSchema.bindService[IO].map(AddService)
+  ).sequence[IO, GrpcConfig]
 }

--- a/docs/src/main/tut/metrics-reporting.md
+++ b/docs/src/main/tut/metrics-reporting.md
@@ -75,11 +75,13 @@ object InterceptingServerCalls extends CommonRuntime {
   implicit val greeterServiceHandler: ServiceHandler[IO] = new ServiceHandler[IO]
 
   // The Greeter service is the service defined in the Core concepts section
-  val grpcConfigs: List[GrpcConfig] = List(
-    AddService(Greeter.bindService[IO].interceptWith(monitorInterceptor))
-  )
+  val grpcConfigs: IO[List[GrpcConfig]] = 
+    Greeter.bindService[IO]
+      .map(_.interceptWith(monitorInterceptor))
+      .map(AddService)
+      .map(List(_))
 
-  val server: IO[GrpcServer[IO]] = GrpcServer.default[IO](8080, grpcConfigs)
+  val server: IO[GrpcServer[IO]] = grpcConfigs.flatMap(GrpcServer.default[IO](8080, _))
 
 }
 ```

--- a/docs/src/main/tut/ssl-tls.md
+++ b/docs/src/main/tut/ssl-tls.md
@@ -111,15 +111,15 @@ trait Runtime extends CommonRuntime {
 
   // Adding to the GrpConfig list the SslContext:
 
-  val grpcConfigs: List[GrpcConfig] = List(
-    SetSslContext(serverSslContext),
-    AddService(Greeter.bindService[IO])
-  )
+  val grpcConfigs: IO[List[GrpcConfig]] =
+     Greeter.bindService[IO]
+       .map(AddService)
+       .map(c => List(SetSslContext(serverSslContext), c))
 
   // Important. We have to create the server with Netty. OkHttp is not supported for the Ssl
   // encryption in mu-rpc at this moment.
 
-  val server: IO[GrpcServer[IO]] = GrpcServer.netty[IO](8080, grpcConfigs)
+  val server: IO[GrpcServer[IO]] = grpcConfigs.flatMap(GrpcServer.netty[IO](8080, _))
 
 }
 

--- a/modules/examples/routeguide/server/src/main/scala/ServerAppIO.scala
+++ b/modules/examples/routeguide/server/src/main/scala/ServerAppIO.scala
@@ -17,7 +17,7 @@
 package example.routeguide.server
 
 import cats.effect.IO
-import higherkindness.mu.rpc.server.{AddService, GrpcConfig, GrpcServer}
+import higherkindness.mu.rpc.server.{AddService, GrpcServer}
 import higherkindness.mu.rpc.server.config.BuildServerFromConfig
 import org.log4s._
 import example.routeguide.protocol.Protocols.RouteGuideService
@@ -25,18 +25,14 @@ import example.routeguide.server.implicits._
 
 object ServerAppIO {
 
-  val logger = getLogger
-
   def main(args: Array[String]): Unit = {
 
-    val grpcConfigs: IO[GrpcConfig] =
-      RouteGuideService.bindService[IO].map(AddService)
-
     val runServer = for {
-      config <- grpcConfigs
-      server <- BuildServerFromConfig[IO]("rpc.server.port", List(config))
-      _      <- IO(logger.info(s"Server is starting ..."))
-      _      <- GrpcServer.server[IO](server)
+      logger      <- IO(getLogger)
+      grpcConfigs <- RouteGuideService.bindService[IO].map(AddService)
+      server      <- BuildServerFromConfig[IO]("rpc.server.port", List(grpcConfigs))
+      _           <- IO(logger.info(s"Server is starting ..."))
+      _           <- GrpcServer.server[IO](server)
     } yield ()
 
     runServer.unsafeRunSync

--- a/modules/examples/routeguide/server/src/main/scala/ServerAppIO.scala
+++ b/modules/examples/routeguide/server/src/main/scala/ServerAppIO.scala
@@ -29,12 +29,12 @@ object ServerAppIO {
 
   def main(args: Array[String]): Unit = {
 
-    val grpcConfigs: List[GrpcConfig] = List(
-      AddService(RouteGuideService.bindService[IO])
-    )
+    val grpcConfigs: IO[GrpcConfig] =
+      RouteGuideService.bindService[IO].map(AddService)
 
     val runServer = for {
-      server <- BuildServerFromConfig[IO]("rpc.server.port", grpcConfigs)
+      config <- grpcConfigs
+      server <- BuildServerFromConfig[IO]("rpc.server.port", List(config))
       _      <- IO(logger.info(s"Server is starting ..."))
       _      <- GrpcServer.server[IO](server)
     } yield ()

--- a/modules/examples/todolist/protocol/src/main/scala/PingPongProtocol.scala
+++ b/modules/examples/todolist/protocol/src/main/scala/PingPongProtocol.scala
@@ -26,7 +26,7 @@ trait PingPongProtocol {
    *
    * @param time Current timestamp.
    */
-  final case class Pong(time: Long = System.currentTimeMillis() / 1000L)
+  case class Pong(time: Long = System.currentTimeMillis() / 1000L)
 
   @service(Protobuf)
   trait PingPongService[F[_]] {

--- a/modules/examples/todolist/protocol/src/main/scala/TagProtocol.scala
+++ b/modules/examples/todolist/protocol/src/main/scala/TagProtocol.scala
@@ -21,13 +21,13 @@ import higherkindness.mu.rpc.protocol._
 
 trait TagProtocol {
 
-  final case class TagRequest(name: String)
+  case class TagRequest(name: String)
 
-  final case class TagMessage(name: String, id: Int)
+  case class TagMessage(name: String, id: Int)
 
-  final case class TagList(list: List[TagMessage])
+  case class TagList(list: List[TagMessage])
 
-  final case class TagResponse(tag: Option[TagMessage])
+  case class TagResponse(tag: Option[TagMessage])
 
   @service(Avro)
   trait TagRpcService[F[_]] {

--- a/modules/examples/todolist/protocol/src/main/scala/TodoItemProtocol.scala
+++ b/modules/examples/todolist/protocol/src/main/scala/TodoItemProtocol.scala
@@ -21,13 +21,13 @@ import higherkindness.mu.rpc.protocol._
 
 trait TodoItemProtocol {
 
-  final case class TodoItemMessage(item: String, todoListId: Int, completed: Boolean, id: Int)
+  case class TodoItemMessage(item: String, todoListId: Int, completed: Boolean, id: Int)
 
-  final case class TodoItemRequest(item: String, todoListId: Int)
+  case class TodoItemRequest(item: String, todoListId: Int)
 
-  final case class TodoItemList(list: List[TodoItemMessage])
+  case class TodoItemList(list: List[TodoItemMessage])
 
-  final case class TodoItemResponse(msg: Option[TodoItemMessage])
+  case class TodoItemResponse(msg: Option[TodoItemMessage])
 
   @service(Avro)
   trait TodoItemRpcService[F[_]] {

--- a/modules/examples/todolist/server/src/main/scala/ServerApp.scala
+++ b/modules/examples/todolist/server/src/main/scala/ServerApp.scala
@@ -27,13 +27,14 @@ import higherkindness.mu.rpc.server.{AddService, GrpcConfig, GrpcServer}
 object ServerApp {
 
   def main(args: Array[String]): Unit = {
+
     val grpcConfigs: IO[List[GrpcConfig]] =
       List(
-        PingPongService.bindService[IO].map(AddService),
-        TagRpcService.bindService[IO].map(AddService),
-        TodoListRpcService.bindService[IO].map(AddService),
-        TodoItemRpcService.bindService[IO].map(AddService)
-      ).sequence[IO, GrpcConfig]
+        PingPongService.bindService[IO],
+        TagRpcService.bindService[IO],
+        TodoListRpcService.bindService[IO],
+        TodoItemRpcService.bindService[IO]
+      ).sequence.map(_.map(AddService))
 
     val runServer = for {
       config <- grpcConfigs

--- a/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/serviceImpl.scala
+++ b/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/serviceImpl.scala
@@ -165,8 +165,9 @@ object serviceImpl {
           F: _root_.cats.effect.ConcurrentEffect[$F],
           algebra: $serviceName[$F],
           EC: _root_.scala.concurrent.ExecutionContext
-        ): _root_.io.grpc.ServerServiceDefinition =
-          new _root_.higherkindness.mu.rpc.internal.service.GRPCServiceDefBuilder(${lit(serviceName)}, ..$serverCallDescriptorsAndHandlers).apply
+        ): $F[_root_.io.grpc.ServerServiceDefinition] =
+          _root_.higherkindness.mu.rpc.internal.service.GRPCServiceDefBuilder.build[$F](${lit(
+        serviceName)}, ..$serverCallDescriptorsAndHandlers)
         """
 
       private val clientCallMethods: List[Tree] = rpcRequests.map(_.clientDef)

--- a/modules/internal/src/test/scala/higherkindness/mu/rpc/internal/GRPCServiceDefBuilderTests.scala
+++ b/modules/internal/src/test/scala/higherkindness/mu/rpc/internal/GRPCServiceDefBuilderTests.scala
@@ -17,6 +17,7 @@
 package higherkindness.mu.rpc
 package internal
 
+import cats.effect.IO
 import higherkindness.mu.rpc.common.RpcBaseTestSuite
 import higherkindness.mu.rpc.internal.service.GRPCServiceDefBuilder
 import io.grpc._
@@ -41,18 +42,19 @@ class GRPCServiceDefBuilderTests extends RpcBaseTestSuite {
     "build a ServerServiceDefinition based on the provided " +
       "MethodDescriptor's and ServerCallHandler's" in {
 
-      val gRPCServiceDefBuilder =
-        new GRPCServiceDefBuilder(serviceName, (flowMethod, handler))
-
-      gRPCServiceDefBuilder.apply.getServiceDescriptor.getName shouldBe serviceName
+      GRPCServiceDefBuilder
+        .build[IO](serviceName, (flowMethod, handler))
+        .map(_.getServiceDescriptor.getName)
+        .unsafeRunSync() shouldBe serviceName
     }
 
     "throw an java.lang.IllegalArgumentException when the serviceName is not valid" in {
 
       val gRPCServiceDefBuilder =
-        new GRPCServiceDefBuilder(invalidServiceName, (flowMethod, handler))
+        GRPCServiceDefBuilder
+          .build[IO](invalidServiceName, (flowMethod, handler))
 
-      an[IllegalArgumentException] should be thrownBy gRPCServiceDefBuilder.apply
+      an[IllegalArgumentException] should be thrownBy gRPCServiceDefBuilder.unsafeRunSync()
     }
 
   }

--- a/modules/marshallers/jodatime/src/test/scala/higherkindness/mu/rpc/protocol/RPCJodaLocalDateTests.scala
+++ b/modules/marshallers/jodatime/src/test/scala/higherkindness/mu/rpc/protocol/RPCJodaLocalDateTests.scala
@@ -19,12 +19,13 @@ package protocol
 
 import org.joda.time._
 import cats.Applicative
-import cats.effect.{IO, Resource}
+import cats.effect.Resource
 import cats.syntax.applicative._
 import com.fortysevendeg.scalacheck.datetime.instances.joda._
 import com.fortysevendeg.scalacheck.datetime.GenDateTime._
 import higherkindness.mu.rpc.common._
 import higherkindness.mu.rpc.testing.servers.withServerChannel
+import io.grpc.{ManagedChannel, ServerServiceDefinition}
 import org.scalacheck.Arbitrary
 import org.scalatest._
 import org.scalacheck.Prop._
@@ -32,8 +33,14 @@ import org.scalatest.prop.Checkers
 
 class RPCJodaLocalDateTests extends RpcBaseTestSuite with BeforeAndAfterAll with Checkers {
 
-  def withClient[Client, A](resource: Resource[ConcurrentMonad, Client])(f: Client => A): A =
-    resource.use(client => IO(f(client))).unsafeRunSync()
+  def withClient[Client, A](
+      serviceDef: ConcurrentMonad[ServerServiceDefinition],
+      resourceBuilder: ConcurrentMonad[ManagedChannel] => Resource[ConcurrentMonad, Client])(
+      f: Client => A): A =
+    withServerChannel(serviceDef)
+      .flatMap(sc => resourceBuilder(suspendM(sc.channel)))
+      .use(client => suspendM(f(client)))
+      .unsafeRunSync()
 
   object RPCJodaLocalDateService {
 
@@ -98,16 +105,15 @@ class RPCJodaLocalDateTests extends RpcBaseTestSuite with BeforeAndAfterAll with
 
     "be able to serialize and deserialize joda.time.LocalDate using proto format" in {
 
-      withServerChannel(ProtobufService.Def.bindService[ConcurrentMonad]) { sc =>
-        withClient(ProtobufService.Def.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll(genDateTimeWithinRange(from, range)) { dt: DateTime =>
-                val date = dt.toLocalDate
-                client.jodaLocalDateProto(date).unsafeRunSync() == date
+      withClient(
+        ProtobufService.Def.bindService[ConcurrentMonad],
+        ProtobufService.Def.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll(genDateTimeWithinRange(from, range)) { dt: DateTime =>
+            val date = dt.toLocalDate
+            client.jodaLocalDateProto(date).unsafeRunSync() == date
 
-              }
-            }
+          }
         }
 
       }
@@ -115,20 +121,19 @@ class RPCJodaLocalDateTests extends RpcBaseTestSuite with BeforeAndAfterAll with
 
     "be able to serialize and deserialize joda.time.LocalDate in a Request using proto format" in {
 
-      withServerChannel(ProtobufService.Def.bindService[ConcurrentMonad]) { sc =>
-        withClient(ProtobufService.Def.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
-                (dt: DateTime, s: String) =>
-                  val date = dt.toLocalDate
-                  client.jodaLocalDateReqProto(Request(date, s)).unsafeRunSync() == Response(
-                    date,
-                    s,
-                    check = true
-                  )
-              }
-            }
+      withClient(
+        ProtobufService.Def.bindService[ConcurrentMonad],
+        ProtobufService.Def.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
+            (dt: DateTime, s: String) =>
+              val date = dt.toLocalDate
+              client.jodaLocalDateReqProto(Request(date, s)).unsafeRunSync() == Response(
+                date,
+                s,
+                check = true
+              )
+          }
         }
 
       }
@@ -136,14 +141,14 @@ class RPCJodaLocalDateTests extends RpcBaseTestSuite with BeforeAndAfterAll with
 
     "be able to serialize and deserialize joda.time.LocalDate using avro format" in {
 
-      withServerChannel(AvroService.Def.bindService[ConcurrentMonad]) { sc =>
-        withClient(AvroService.Def.clientFromChannel[ConcurrentMonad](IO(sc.channel))) { client =>
-          check {
-            forAll(genDateTimeWithinRange(from, range)) { dt: DateTime =>
-              val date = dt.toLocalDate
-              client.jodaLocalDateAvro(date).unsafeRunSync() == date
+      withClient(
+        AvroService.Def.bindService[ConcurrentMonad],
+        AvroService.Def.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll(genDateTimeWithinRange(from, range)) { dt: DateTime =>
+            val date = dt.toLocalDate
+            client.jodaLocalDateAvro(date).unsafeRunSync() == date
 
-            }
           }
         }
 
@@ -152,34 +157,34 @@ class RPCJodaLocalDateTests extends RpcBaseTestSuite with BeforeAndAfterAll with
 
     "be able to serialize and deserialize joda.time.LocalDate in a Request using avro format" in {
 
-      withServerChannel(AvroService.Def.bindService[ConcurrentMonad]) { sc =>
-        withClient(AvroService.Def.clientFromChannel[ConcurrentMonad](IO(sc.channel))) { client =>
-          check {
-            forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
-              (dt: DateTime, s: String) =>
-                val date = dt.toLocalDate
-                client.jodaLocalDateReqAvro(Request(date, s)).unsafeRunSync() == Response(
-                  date,
-                  s,
-                  check = true
-                )
-            }
+      withClient(
+        AvroService.Def.bindService[ConcurrentMonad],
+        AvroService.Def.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
+            (dt: DateTime, s: String) =>
+              val date = dt.toLocalDate
+              client.jodaLocalDateReqAvro(Request(date, s)).unsafeRunSync() == Response(
+                date,
+                s,
+                check = true
+              )
           }
         }
+
       }
     }
 
     "be able to serialize and deserialize joda.time.LocalDate using avro with schema format" in {
 
-      withServerChannel(AvroService.WithSchemaDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(AvroService.WithSchemaDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll(genDateTimeWithinRange(from, range)) { dt: DateTime =>
-                val date = dt.toLocalDate
-                client.localDateAvroWithSchema(date).unsafeRunSync() == date
-              }
-            }
+      withClient(
+        AvroService.WithSchemaDef.bindService[ConcurrentMonad],
+        AvroService.WithSchemaDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll(genDateTimeWithinRange(from, range)) { dt: DateTime =>
+            val date = dt.toLocalDate
+            client.localDateAvroWithSchema(date).unsafeRunSync() == date
+          }
         }
 
       }
@@ -187,23 +192,23 @@ class RPCJodaLocalDateTests extends RpcBaseTestSuite with BeforeAndAfterAll with
 
     "be able to serialize and deserialize joda.time.LocalDate in a Request using avro with schema format" in {
 
-      withServerChannel(AvroService.WithSchemaDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(AvroService.WithSchemaDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
-                (dt: DateTime, s: String) =>
-                  val date = dt.toLocalDate
-                  client
-                    .jodaLocalDateReqAvroWithSchema(Request(date, s))
-                    .unsafeRunSync() == Response(
-                    date,
-                    s,
-                    check = true
-                  )
-              }
-            }
+      withClient(
+        AvroService.WithSchemaDef.bindService[ConcurrentMonad],
+        AvroService.WithSchemaDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
+            (dt: DateTime, s: String) =>
+              val date = dt.toLocalDate
+              client
+                .jodaLocalDateReqAvroWithSchema(Request(date, s))
+                .unsafeRunSync() == Response(
+                date,
+                s,
+                check = true
+              )
+          }
         }
+
       }
     }
 

--- a/modules/prometheus/client/src/test/scala/higherkindness/mu/rpc/prometheus/client/InterceptorsRuntime.scala
+++ b/modules/prometheus/client/src/test/scala/higherkindness/mu/rpc/prometheus/client/InterceptorsRuntime.scala
@@ -44,10 +44,10 @@ case class InterceptorsRuntime(
   //////////////////////////////////
 
   lazy val grpcConfigs: ConcurrentMonad[List[GrpcConfig]] = List(
-    ProtoRPCService.bindService[ConcurrentMonad].map(AddService),
-    AvroRPCService.bindService[ConcurrentMonad].map(AddService),
-    AvroWithSchemaRPCService.bindService[ConcurrentMonad].map(AddService)
-  ).sequence
+    ProtoRPCService.bindService[ConcurrentMonad],
+    AvroRPCService.bindService[ConcurrentMonad],
+    AvroWithSchemaRPCService.bindService[ConcurrentMonad]
+  ).sequence.map(_.map(AddService))
 
   implicit lazy val grpcServer: GrpcServer[ConcurrentMonad] =
     grpcConfigs.flatMap(createServerConfOnRandomPort[ConcurrentMonad]).unsafeRunSync

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/CommonUtils.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/CommonUtils.scala
@@ -19,7 +19,7 @@ package higherkindness.mu.rpc
 import java.net.ServerSocket
 
 import cats.Functor
-import cats.effect.{IO, Resource, Sync}
+import cats.effect.{Resource, Sync}
 import cats.syntax.functor._
 import higherkindness.mu.rpc.common._
 import higherkindness.mu.rpc.server._
@@ -88,10 +88,7 @@ trait CommonUtils {
         throw new RuntimeException(e)
     }
 
-  def withClient[Client, A](resource: Resource[ConcurrentMonad, Client])(f: Client => A): A =
-    resource.use(client => IO(f(client))).unsafeRunSync()
-
-  def withClientF[Client, A](
+  def withClient[Client, A](
       serviceDef: ConcurrentMonad[ServerServiceDefinition],
       resourceBuilder: ConcurrentMonad[ManagedChannel] => Resource[ConcurrentMonad, Client])(
       f: Client => A): A =

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/fs2/Utils.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/fs2/Utils.scala
@@ -143,6 +143,8 @@ object Utils extends CommonUtils {
     import service._
     import handlers.server._
     import higherkindness.mu.rpc.server._
+    import cats.instances.list._
+    import cats.syntax.traverse._
 
     //////////////////////////////////
     // Server Runtime Configuration //
@@ -151,17 +153,17 @@ object Utils extends CommonUtils {
     implicit val muRPCHandler: ServerRPCService[ConcurrentMonad] =
       new ServerRPCService[ConcurrentMonad]
 
-    val grpcConfigs: List[GrpcConfig] = List(
-      AddService(ProtoRPCService.bindService[ConcurrentMonad]),
-      AddService(AvroRPCService.bindService[ConcurrentMonad]),
-      AddService(AvroWithSchemaRPCService.bindService[ConcurrentMonad]),
-      AddService(CompressedProtoRPCService.bindService[ConcurrentMonad]),
-      AddService(CompressedAvroRPCService.bindService[ConcurrentMonad]),
-      AddService(CompressedAvroWithSchemaRPCService.bindService[ConcurrentMonad])
-    )
+    val grpcConfigs: ConcurrentMonad[List[GrpcConfig]] = List(
+      ProtoRPCService.bindService[ConcurrentMonad].map(AddService),
+      AvroRPCService.bindService[ConcurrentMonad].map(AddService),
+      AvroWithSchemaRPCService.bindService[ConcurrentMonad].map(AddService),
+      CompressedProtoRPCService.bindService[ConcurrentMonad].map(AddService),
+      CompressedAvroRPCService.bindService[ConcurrentMonad].map(AddService),
+      CompressedAvroWithSchemaRPCService.bindService[ConcurrentMonad].map(AddService)
+    ).sequence
 
     implicit val grpcServer: GrpcServer[ConcurrentMonad] =
-      createServerConf[ConcurrentMonad](grpcConfigs).unsafeRunSync
+      grpcConfigs.flatMap(createServerConf[ConcurrentMonad]).unsafeRunSync
 
     //////////////////////////////////
     // Client Runtime Configuration //

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/fs2/Utils.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/fs2/Utils.scala
@@ -154,13 +154,13 @@ object Utils extends CommonUtils {
       new ServerRPCService[ConcurrentMonad]
 
     val grpcConfigs: ConcurrentMonad[List[GrpcConfig]] = List(
-      ProtoRPCService.bindService[ConcurrentMonad].map(AddService),
-      AvroRPCService.bindService[ConcurrentMonad].map(AddService),
-      AvroWithSchemaRPCService.bindService[ConcurrentMonad].map(AddService),
-      CompressedProtoRPCService.bindService[ConcurrentMonad].map(AddService),
-      CompressedAvroRPCService.bindService[ConcurrentMonad].map(AddService),
-      CompressedAvroWithSchemaRPCService.bindService[ConcurrentMonad].map(AddService)
-    ).sequence
+      ProtoRPCService.bindService[ConcurrentMonad],
+      AvroRPCService.bindService[ConcurrentMonad],
+      AvroWithSchemaRPCService.bindService[ConcurrentMonad],
+      CompressedProtoRPCService.bindService[ConcurrentMonad],
+      CompressedAvroRPCService.bindService[ConcurrentMonad],
+      CompressedAvroWithSchemaRPCService.bindService[ConcurrentMonad]
+    ).sequence.map(_.map(AddService))
 
     implicit val grpcServer: GrpcServer[ConcurrentMonad] =
       grpcConfigs.flatMap(createServerConf[ConcurrentMonad]).unsafeRunSync

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCBigDecimalTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCBigDecimalTests.scala
@@ -140,7 +140,7 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
     "be able to serialize and deserialize BigDecimal using proto format" in {
 
-      withClientF(
+      withClient(
         ProtoRPCServiceDef.bindService[ConcurrentMonad],
         ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
@@ -154,7 +154,7 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
     "be able to serialize and deserialize BigDecimal in a Request using proto format" in {
 
-      withClientF(
+      withClient(
         ProtoRPCServiceDef.bindService[ConcurrentMonad],
         ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
@@ -171,7 +171,7 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
     "be able to serialize and deserialize BigDecimal using avro format" in {
 
-      withClientF(
+      withClient(
         AvroRPCServiceDef.bindService[ConcurrentMonad],
         AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
@@ -185,7 +185,7 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
     "be able to serialize and deserialize BigDecimal in a Request using avro format" in {
 
-      withClientF(
+      withClient(
         AvroRPCServiceDef.bindService[ConcurrentMonad],
         AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
@@ -204,7 +204,7 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
     "be able to serialize and deserialize BigDecimal using avro with schema format" in {
 
-      withClientF(
+      withClient(
         AvroWithSchemaRPCServiceDef.bindService[ConcurrentMonad],
         AvroWithSchemaRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
@@ -220,7 +220,7 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
     "be able to serialize and deserialize BigDecimal in a Request using avro with schema format" in {
 
-      withClientF(
+      withClient(
         AvroWithSchemaRPCServiceDef.bindService[ConcurrentMonad],
         AvroWithSchemaRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
@@ -249,7 +249,7 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
     "be able to serialize and deserialize BigDecimal using avro format" in {
 
-      withClientF(
+      withClient(
         AvroRPCServiceDef.bindService[ConcurrentMonad],
         AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
@@ -266,7 +266,7 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
     "be able to serialize and deserialize BigDecimal in a Request using avro" in {
 
-      withClientF(
+      withClient(
         AvroRPCServiceDef.bindService[ConcurrentMonad],
         AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCBigDecimalTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCBigDecimalTests.scala
@@ -18,15 +18,13 @@ package higherkindness.mu.rpc
 package protocol
 
 import cats.Applicative
-import cats.effect.IO
 import cats.syntax.applicative._
 import org.scalatest._
 import higherkindness.mu.rpc.common._
 import higherkindness.mu.rpc.internal.encoders.avro.bigDecimalTagged._
 import higherkindness.mu.rpc.internal.encoders.avro.bigDecimalTagged.marshallers._
 import higherkindness.mu.rpc.internal.encoders.pbd.bigDecimal._
-import higherkindness.mu.rpc.protocol.Utils.withClient
-import higherkindness.mu.rpc.testing.servers.withServerChannel
+import higherkindness.mu.rpc.protocol.Utils._
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Prop._
 import org.scalatest.prop.Checkers
@@ -142,14 +140,13 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
     "be able to serialize and deserialize BigDecimal using proto format" in {
 
-      withServerChannel(ProtoRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll { bd: BigDecimal =>
-                client.bigDecimalProto(bd).unsafeRunSync() == bd
-              }
-            }
+      withClientF(
+        ProtoRPCServiceDef.bindService[ConcurrentMonad],
+        ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll { bd: BigDecimal =>
+            client.bigDecimalProto(bd).unsafeRunSync() == bd
+          }
         }
       }
 
@@ -157,17 +154,16 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
     "be able to serialize and deserialize BigDecimal in a Request using proto format" in {
 
-      withServerChannel(ProtoRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll { (bd: BigDecimal, s: String) =>
-                client.bigDecimalProtoWrapper(Request(bd, s)).unsafeRunSync() == Response(
-                  bd,
-                  s,
-                  check = true)
-              }
-            }
+      withClientF(
+        ProtoRPCServiceDef.bindService[ConcurrentMonad],
+        ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll { (bd: BigDecimal, s: String) =>
+            client.bigDecimalProtoWrapper(Request(bd, s)).unsafeRunSync() == Response(
+              bd,
+              s,
+              check = true)
+          }
         }
       }
 
@@ -175,12 +171,12 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
     "be able to serialize and deserialize BigDecimal using avro format" in {
 
-      withServerChannel(AvroRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) { client =>
-          check {
-            forAll(bigDecimalGen(2)) { bd =>
-              client.bigDecimalAvro(tag[(Nat._8, Nat._2)][BigDecimal](bd)).unsafeRunSync() == bd
-            }
+      withClientF(
+        AvroRPCServiceDef.bindService[ConcurrentMonad],
+        AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll(bigDecimalGen(2)) { bd =>
+            client.bigDecimalAvro(tag[(Nat._8, Nat._2)][BigDecimal](bd)).unsafeRunSync() == bd
           }
         }
       }
@@ -189,59 +185,58 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
     "be able to serialize and deserialize BigDecimal in a Request using avro format" in {
 
-      withServerChannel(AvroRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) { client =>
-          check {
-            forAll { request: RequestPS =>
-              client.bigDecimalAvroWrapper(request).unsafeRunSync() == ResponsePS(
-                request.bd1,
-                request.bd2,
-                request.bd3,
-                request.label,
-                check = true)
-            }
+      withClientF(
+        AvroRPCServiceDef.bindService[ConcurrentMonad],
+        AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll { request: RequestPS =>
+            client.bigDecimalAvroWrapper(request).unsafeRunSync() == ResponsePS(
+              request.bd1,
+              request.bd2,
+              request.bd3,
+              request.label,
+              check = true)
           }
         }
-
       }
+
     }
 
     "be able to serialize and deserialize BigDecimal using avro with schema format" in {
 
-      withServerChannel(AvroWithSchemaRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(AvroWithSchemaRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll(bigDecimalGen(2)) { bd =>
-                client
-                  .bigDecimalAvroWithSchema(tag[(Nat._8, Nat._2)][BigDecimal](bd))
-                  .unsafeRunSync() == bd
-              }
-            }
+      withClientF(
+        AvroWithSchemaRPCServiceDef.bindService[ConcurrentMonad],
+        AvroWithSchemaRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll(bigDecimalGen(2)) { bd =>
+            client
+              .bigDecimalAvroWithSchema(tag[(Nat._8, Nat._2)][BigDecimal](bd))
+              .unsafeRunSync() == bd
+          }
         }
-
       }
+
     }
 
     "be able to serialize and deserialize BigDecimal in a Request using avro with schema format" in {
 
-      withServerChannel(AvroWithSchemaRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(AvroWithSchemaRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll { request: RequestPS =>
-                client
-                  .bigDecimalAvroWithSchemaWrapper(request)
-                  .unsafeRunSync() == ResponsePS(
-                  request.bd1,
-                  request.bd2,
-                  request.bd3,
-                  request.label,
-                  check = true)
-              }
-            }
+      withClientF(
+        AvroWithSchemaRPCServiceDef.bindService[ConcurrentMonad],
+        AvroWithSchemaRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll { request: RequestPS =>
+            client
+              .bigDecimalAvroWithSchemaWrapper(request)
+              .unsafeRunSync() == ResponsePS(
+              request.bd1,
+              request.bd2,
+              request.bd3,
+              request.label,
+              check = true)
+          }
         }
       }
+
     }
   }
 
@@ -254,15 +249,15 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
     "be able to serialize and deserialize BigDecimal using avro format" in {
 
-      withServerChannel(AvroRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) { client =>
-          check {
-            forAll(bigDecimalGen(12)) { bd =>
-              client
-                .bigDecimalAvro(tag[(Nat._8, Nat._2)][BigDecimal](bd))
-                .unsafeRunSync() == bd
-                .setScale(2, RM)
-            }
+      withClientF(
+        AvroRPCServiceDef.bindService[ConcurrentMonad],
+        AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll(bigDecimalGen(12)) { bd =>
+            client
+              .bigDecimalAvro(tag[(Nat._8, Nat._2)][BigDecimal](bd))
+              .unsafeRunSync() == bd
+              .setScale(2, RM)
           }
         }
       }
@@ -271,21 +266,22 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
     "be able to serialize and deserialize BigDecimal in a Request using avro" in {
 
-      withServerChannel(AvroRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) { client =>
-          check {
-            forAll(bigDecimalGen(12)) { bd =>
-              val bdTagged = tag[(Nat._8, Nat._2)][BigDecimal](bd)
-              client
-                .bigDecimalAvroWrapper(Request(tag[(Nat._8, Nat._2)][BigDecimal](bd), "label"))
-                .unsafeRunSync() == Response(
-                tag[(Nat._8, Nat._2)][BigDecimal](bd.setScale(2, RM)),
-                "label",
-                check = true)
-            }
+      withClientF(
+        AvroRPCServiceDef.bindService[ConcurrentMonad],
+        AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll(bigDecimalGen(12)) { bd =>
+            val bdTagged = tag[(Nat._8, Nat._2)][BigDecimal](bd)
+            client
+              .bigDecimalAvroWrapper(Request(tag[(Nat._8, Nat._2)][BigDecimal](bd), "label"))
+              .unsafeRunSync() == Response(
+              tag[(Nat._8, Nat._2)][BigDecimal](bd.setScale(2, RM)),
+              "label",
+              check = true)
           }
         }
       }
+
     }
   }
 }

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCJavaTimeTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCJavaTimeTests.scala
@@ -20,7 +20,6 @@ package protocol
 import java.time._
 
 import cats.Applicative
-import cats.effect.IO
 import cats.syntax.applicative._
 import com.fortysevendeg.scalacheck.datetime.instances.jdk8._
 import com.fortysevendeg.scalacheck.datetime.GenDateTime._
@@ -28,8 +27,7 @@ import com.fortysevendeg.scalacheck.datetime.jdk8.granularity.seconds
 import higherkindness.mu.rpc.common._
 import higherkindness.mu.rpc.internal.encoders.avro.javatime.marshallers._
 import higherkindness.mu.rpc.internal.encoders.pbd.javatime._
-import higherkindness.mu.rpc.protocol.Utils.withClient
-import higherkindness.mu.rpc.testing.servers.withServerChannel
+import higherkindness.mu.rpc.protocol.Utils._
 import org.scalacheck.Arbitrary
 import org.scalatest._
 import org.scalacheck.Prop._
@@ -109,15 +107,14 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize LocalDate using proto format" in {
 
-      withServerChannel(ProtoRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
-                val date = zdt.toLocalDate
-                client.localDateProto(date).unsafeRunSync() == date
-              }
-            }
+      withClientF(
+        ProtoRPCDateServiceDef.bindService[ConcurrentMonad],
+        ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
+            val date = zdt.toLocalDate
+            client.localDateProto(date).unsafeRunSync() == date
+          }
         }
       }
 
@@ -125,15 +122,14 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize LocalDateTime using proto format" in {
 
-      withServerChannel(ProtoRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
-                val dateTime = zdt.toLocalDateTime
-                client.localDateTimeProto(dateTime).unsafeRunSync() == dateTime
-              }
-            }
+      withClientF(
+        ProtoRPCDateServiceDef.bindService[ConcurrentMonad],
+        ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
+            val dateTime = zdt.toLocalDateTime
+            client.localDateTimeProto(dateTime).unsafeRunSync() == dateTime
+          }
         }
       }
 
@@ -141,15 +137,14 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize Instant using proto format" in {
 
-      withServerChannel(ProtoRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
-                val instant = zdt.toInstant
-                client.instantProto(instant).unsafeRunSync() == instant
-              }
-            }
+      withClientF(
+        ProtoRPCDateServiceDef.bindService[ConcurrentMonad],
+        ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
+            val instant = zdt.toInstant
+            client.instantProto(instant).unsafeRunSync() == instant
+          }
         }
       }
 
@@ -157,52 +152,51 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize LocalDate, LocalDateTime, and Instant in a Request using proto format" in {
 
-      withServerChannel(ProtoRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
-                (zdt: ZonedDateTime, s: String) =>
-                  val date     = zdt.toLocalDate
-                  val dateTime = zdt.toLocalDateTime
-                  val instant  = zdt.toInstant
-                  client
-                    .dateProtoWrapper(Request(date, dateTime, instant, s))
-                    .unsafeRunSync() == Response(date, dateTime, instant, s, check = true)
-              }
-            }
+      withClientF(
+        ProtoRPCDateServiceDef.bindService[ConcurrentMonad],
+        ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
+            (zdt: ZonedDateTime, s: String) =>
+              val date     = zdt.toLocalDate
+              val dateTime = zdt.toLocalDateTime
+              val instant  = zdt.toInstant
+              client
+                .dateProtoWrapper(Request(date, dateTime, instant, s))
+                .unsafeRunSync() == Response(date, dateTime, instant, s, check = true)
+          }
         }
+
       }
 
     }
 
     "be able to serialize and deserialize LocalDate using avro format" in {
 
-      withServerChannel(AvroRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
-                val date = zdt.toLocalDate
-                client.localDateAvro(date).unsafeRunSync() == date
-              }
-            }
+      withClientF(
+        AvroRPCDateServiceDef.bindService[ConcurrentMonad],
+        AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
+            val date = zdt.toLocalDate
+            client.localDateAvro(date).unsafeRunSync() == date
+          }
         }
+
       }
 
     }
 
     "be able to serialize and deserialize LocalDateTime using avro format" in {
 
-      withServerChannel(AvroRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
-                val dateTime = zdt.toLocalDateTime
-                client.localDateTimeAvro(dateTime).unsafeRunSync() == dateTime
-              }
-            }
+      withClientF(
+        AvroRPCDateServiceDef.bindService[ConcurrentMonad],
+        AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
+            val dateTime = zdt.toLocalDateTime
+            client.localDateTimeAvro(dateTime).unsafeRunSync() == dateTime
+          }
         }
       }
 
@@ -210,110 +204,106 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize Instant using avro format" in {
 
-      withServerChannel(AvroRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
-                val instant = zdt.toInstant
-                client.instantAvro(instant).unsafeRunSync() == instant
-              }
-            }
+      withClientF(
+        AvroRPCDateServiceDef.bindService[ConcurrentMonad],
+        AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
+            val instant = zdt.toInstant
+            client.instantAvro(instant).unsafeRunSync() == instant
+          }
         }
+
       }
 
     }
 
     "be able to serialize and deserialize LocalDate, LocalDateTime, and Instant in a Request using avro format" in {
 
-      withServerChannel(AvroRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
-                (zdt: ZonedDateTime, s: String) =>
-                  val date     = zdt.toLocalDate
-                  val dateTime = zdt.toLocalDateTime
-                  val instant  = zdt.toInstant
-                  client
-                    .dateAvroWrapper(Request(date, dateTime, instant, s))
-                    .unsafeRunSync() == Response(date, dateTime, instant, s, check = true)
-              }
-            }
+      withClientF(
+        AvroRPCDateServiceDef.bindService[ConcurrentMonad],
+        AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
+            (zdt: ZonedDateTime, s: String) =>
+              val date     = zdt.toLocalDate
+              val dateTime = zdt.toLocalDateTime
+              val instant  = zdt.toInstant
+              client
+                .dateAvroWrapper(Request(date, dateTime, instant, s))
+                .unsafeRunSync() == Response(date, dateTime, instant, s, check = true)
+          }
         }
+
       }
 
     }
 
     "be able to serialize and deserialize LocalDate using avro format with schema" in {
 
-      withServerChannel(AvroWithSchemaRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(
-          AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
-                val date = zdt.toLocalDate
-                client.localDateAvroWithSchema(date).unsafeRunSync() == date
-              }
-            }
+      withClientF(
+        AvroWithSchemaRPCDateServiceDef.bindService[ConcurrentMonad],
+        AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
+            val date = zdt.toLocalDate
+            client.localDateAvroWithSchema(date).unsafeRunSync() == date
+          }
         }
+
       }
 
     }
 
     "be able to serialize and deserialize LocalDateTime using avro format with schema" in {
 
-      withServerChannel(AvroWithSchemaRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(
-          AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
-                val dateTime = zdt.toLocalDateTime
-                client.localDateTimeAvroWithSchema(dateTime).unsafeRunSync() == dateTime
-              }
-            }
+      withClientF(
+        AvroWithSchemaRPCDateServiceDef.bindService[ConcurrentMonad],
+        AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
+            val dateTime = zdt.toLocalDateTime
+            client.localDateTimeAvroWithSchema(dateTime).unsafeRunSync() == dateTime
+          }
         }
+
       }
 
     }
 
     "be able to serialize and deserialize Instant using avro format with schema" in {
 
-      withServerChannel(AvroWithSchemaRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(
-          AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
-                val instant = zdt.toInstant
-                client.instantAvroWithSchema(instant).unsafeRunSync() == instant
-              }
-            }
+      withClientF(
+        AvroWithSchemaRPCDateServiceDef.bindService[ConcurrentMonad],
+        AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
+            val instant = zdt.toInstant
+            client.instantAvroWithSchema(instant).unsafeRunSync() == instant
+          }
         }
+
       }
 
     }
 
     "be able to serialize and deserialize LocalDate, LocalDateTime, and Instant in a Request using avro format with schema" in {
 
-      withServerChannel(AvroWithSchemaRPCDateServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(
-          AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
-                (zdt: ZonedDateTime, s: String) =>
-                  val date     = zdt.toLocalDate
-                  val dateTime = zdt.toLocalDateTime
-                  val instant  = zdt.toInstant
-                  client
-                    .dateAvroWrapperWithSchema(Request(date, dateTime, instant, s))
-                    .unsafeRunSync() == Response(date, dateTime, instant, s, check = true)
-              }
-            }
+      withClientF(
+        AvroWithSchemaRPCDateServiceDef.bindService[ConcurrentMonad],
+        AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll(genDateTimeWithinRange(from, range), Arbitrary.arbitrary[String]) {
+            (zdt: ZonedDateTime, s: String) =>
+              val date     = zdt.toLocalDate
+              val dateTime = zdt.toLocalDateTime
+              val instant  = zdt.toInstant
+              client
+                .dateAvroWrapperWithSchema(Request(date, dateTime, instant, s))
+                .unsafeRunSync() == Response(date, dateTime, instant, s, check = true)
+          }
         }
+
       }
 
     }

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCJavaTimeTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCJavaTimeTests.scala
@@ -107,7 +107,7 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize LocalDate using proto format" in {
 
-      withClientF(
+      withClient(
         ProtoRPCDateServiceDef.bindService[ConcurrentMonad],
         ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
@@ -122,7 +122,7 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize LocalDateTime using proto format" in {
 
-      withClientF(
+      withClient(
         ProtoRPCDateServiceDef.bindService[ConcurrentMonad],
         ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
@@ -137,7 +137,7 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize Instant using proto format" in {
 
-      withClientF(
+      withClient(
         ProtoRPCDateServiceDef.bindService[ConcurrentMonad],
         ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
@@ -152,7 +152,7 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize LocalDate, LocalDateTime, and Instant in a Request using proto format" in {
 
-      withClientF(
+      withClient(
         ProtoRPCDateServiceDef.bindService[ConcurrentMonad],
         ProtoRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
@@ -173,7 +173,7 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize LocalDate using avro format" in {
 
-      withClientF(
+      withClient(
         AvroRPCDateServiceDef.bindService[ConcurrentMonad],
         AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
@@ -189,7 +189,7 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize LocalDateTime using avro format" in {
 
-      withClientF(
+      withClient(
         AvroRPCDateServiceDef.bindService[ConcurrentMonad],
         AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
@@ -204,7 +204,7 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize Instant using avro format" in {
 
-      withClientF(
+      withClient(
         AvroRPCDateServiceDef.bindService[ConcurrentMonad],
         AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
@@ -220,7 +220,7 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize LocalDate, LocalDateTime, and Instant in a Request using avro format" in {
 
-      withClientF(
+      withClient(
         AvroRPCDateServiceDef.bindService[ConcurrentMonad],
         AvroRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
@@ -241,7 +241,7 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize LocalDate using avro format with schema" in {
 
-      withClientF(
+      withClient(
         AvroWithSchemaRPCDateServiceDef.bindService[ConcurrentMonad],
         AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
@@ -257,7 +257,7 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize LocalDateTime using avro format with schema" in {
 
-      withClientF(
+      withClient(
         AvroWithSchemaRPCDateServiceDef.bindService[ConcurrentMonad],
         AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
@@ -273,7 +273,7 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize Instant using avro format with schema" in {
 
-      withClientF(
+      withClient(
         AvroWithSchemaRPCDateServiceDef.bindService[ConcurrentMonad],
         AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
@@ -289,7 +289,7 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize LocalDate, LocalDateTime, and Instant in a Request using avro format with schema" in {
 
-      withClientF(
+      withClient(
         AvroWithSchemaRPCDateServiceDef.bindService[ConcurrentMonad],
         AvroWithSchemaRPCDateServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCProtoProducts.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCProtoProducts.scala
@@ -89,7 +89,7 @@ class RPCProtoProducts extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize Options in the request/response using proto format" in {
 
-      withClientF(
+      withClient(
         ProtoRPCServiceDef.bindService[ConcurrentMonad],
         ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
@@ -106,7 +106,7 @@ class RPCProtoProducts extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize Options in the request/response using avro format" in {
 
-      withClientF(
+      withClient(
         AvroRPCServiceDef.bindService[ConcurrentMonad],
         AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
@@ -123,7 +123,7 @@ class RPCProtoProducts extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize Options in the request/response using avro with schema format" in {
 
-      withClientF(
+      withClient(
         AvroWithSchemaRPCServiceDef.bindService[ConcurrentMonad],
         AvroWithSchemaRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
@@ -140,7 +140,7 @@ class RPCProtoProducts extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize Lists in the request/response using proto format" in {
 
-      withClientF(
+      withClient(
         ProtoRPCServiceDef.bindService[ConcurrentMonad],
         ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
@@ -157,7 +157,7 @@ class RPCProtoProducts extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize Lists in the request/response using avro format" in {
 
-      withClientF(
+      withClient(
         AvroRPCServiceDef.bindService[ConcurrentMonad],
         AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
@@ -173,7 +173,7 @@ class RPCProtoProducts extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize Lists in the request/response using avro with schema format" in {
 
-      withClientF(
+      withClient(
         AvroWithSchemaRPCServiceDef.bindService[ConcurrentMonad],
         AvroWithSchemaRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCProtoProducts.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCProtoProducts.scala
@@ -18,11 +18,9 @@ package higherkindness.mu.rpc
 package protocol
 
 import cats.Applicative
-import cats.effect.IO
 import cats.syntax.applicative._
 import higherkindness.mu.rpc.common._
-import higherkindness.mu.rpc.protocol.Utils.withClient
-import higherkindness.mu.rpc.testing.servers.withServerChannel
+import higherkindness.mu.rpc.protocol.Utils._
 import org.scalatest._
 import org.scalacheck.Prop._
 import org.scalatest.prop.Checkers
@@ -91,16 +89,15 @@ class RPCProtoProducts extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize Options in the request/response using proto format" in {
 
-      withServerChannel(ProtoRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll { maybeString: Option[String] =>
-                client
-                  .optionProto(RequestOption(maybeString.map(MyParam)))
-                  .unsafeRunSync() == ResponseOption(maybeString, true)
-              }
-            }
+      withClientF(
+        ProtoRPCServiceDef.bindService[ConcurrentMonad],
+        ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll { maybeString: Option[String] =>
+            client
+              .optionProto(RequestOption(maybeString.map(MyParam)))
+              .unsafeRunSync() == ResponseOption(maybeString, true)
+          }
         }
 
       }
@@ -109,64 +106,65 @@ class RPCProtoProducts extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize Options in the request/response using avro format" in {
 
-      withServerChannel(AvroRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) { client =>
-          check {
-            forAll { maybeString: Option[String] =>
-              client
-                .optionAvro(RequestOption(maybeString.map(MyParam)))
-                .unsafeRunSync() == ResponseOption(maybeString, true)
-            }
+      withClientF(
+        AvroRPCServiceDef.bindService[ConcurrentMonad],
+        AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll { maybeString: Option[String] =>
+            client
+              .optionAvro(RequestOption(maybeString.map(MyParam)))
+              .unsafeRunSync() == ResponseOption(maybeString, true)
           }
         }
+
       }
 
     }
 
     "be able to serialize and deserialize Options in the request/response using avro with schema format" in {
 
-      withServerChannel(AvroWithSchemaRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(AvroWithSchemaRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll { maybeString: Option[String] =>
-                client
-                  .optionAvroWithSchema(RequestOption(maybeString.map(MyParam)))
-                  .unsafeRunSync() == ResponseOption(maybeString, true)
-              }
-            }
+      withClientF(
+        AvroWithSchemaRPCServiceDef.bindService[ConcurrentMonad],
+        AvroWithSchemaRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll { maybeString: Option[String] =>
+            client
+              .optionAvroWithSchema(RequestOption(maybeString.map(MyParam)))
+              .unsafeRunSync() == ResponseOption(maybeString, true)
+          }
         }
+
       }
 
     }
 
     "be able to serialize and deserialize Lists in the request/response using proto format" in {
 
-      withServerChannel(ProtoRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll { list: List[String] =>
-                client
-                  .listProto(RequestList(list.map(MyParam)))
-                  .unsafeRunSync() == ResponseList(list, true)
-              }
-            }
+      withClientF(
+        ProtoRPCServiceDef.bindService[ConcurrentMonad],
+        ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll { list: List[String] =>
+            client
+              .listProto(RequestList(list.map(MyParam)))
+              .unsafeRunSync() == ResponseList(list, true)
+          }
         }
+
       }
 
     }
 
     "be able to serialize and deserialize Lists in the request/response using avro format" in {
 
-      withServerChannel(AvroRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) { client =>
-          check {
-            forAll { list: List[String] =>
-              client
-                .listAvro(RequestList(list.map(MyParam)))
-                .unsafeRunSync() == ResponseList(list, true)
-            }
+      withClientF(
+        AvroRPCServiceDef.bindService[ConcurrentMonad],
+        AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll { list: List[String] =>
+            client
+              .listAvro(RequestList(list.map(MyParam)))
+              .unsafeRunSync() == ResponseList(list, true)
           }
         }
       }
@@ -175,17 +173,17 @@ class RPCProtoProducts extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     "be able to serialize and deserialize Lists in the request/response using avro with schema format" in {
 
-      withServerChannel(AvroWithSchemaRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
-        withClient(AvroWithSchemaRPCServiceDef.clientFromChannel[ConcurrentMonad](IO(sc.channel))) {
-          client =>
-            check {
-              forAll { list: List[String] =>
-                client
-                  .listAvroWithSchema(RequestList(list.map(MyParam)))
-                  .unsafeRunSync() == ResponseList(list, true)
-              }
-            }
+      withClientF(
+        AvroWithSchemaRPCServiceDef.bindService[ConcurrentMonad],
+        AvroWithSchemaRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
+        check {
+          forAll { list: List[String] =>
+            client
+              .listAvroWithSchema(RequestList(list.map(MyParam)))
+              .unsafeRunSync() == ResponseList(list, true)
+          }
         }
+
       }
 
     }

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/Utils.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/Utils.scala
@@ -500,16 +500,16 @@ object Utils extends CommonUtils {
       new ServerRPCService[ConcurrentMonad]
 
     val grpcConfigs: ConcurrentMonad[List[GrpcConfig]] = List(
-      ProtoRPCService.bindService[ConcurrentMonad].map(AddService),
-      AvroRPCService.bindService[ConcurrentMonad].map(AddService),
-      AvroWithSchemaRPCService.bindService[ConcurrentMonad].map(AddService),
-      CompressedProtoRPCService.bindService[ConcurrentMonad].map(AddService),
-      CompressedAvroRPCService.bindService[ConcurrentMonad].map(AddService),
-      CompressedAvroWithSchemaRPCService.bindService[ConcurrentMonad].map(AddService)
-    ).sequence
+      ProtoRPCService.bindService[ConcurrentMonad],
+      AvroRPCService.bindService[ConcurrentMonad],
+      AvroWithSchemaRPCService.bindService[ConcurrentMonad],
+      CompressedProtoRPCService.bindService[ConcurrentMonad],
+      CompressedAvroRPCService.bindService[ConcurrentMonad],
+      CompressedAvroWithSchemaRPCService.bindService[ConcurrentMonad]
+    ).sequence.map(_.map(AddService))
 
     implicit val grpcServer: GrpcServer[ConcurrentMonad] =
-      grpcConfigs.flatMap(createServerConf[ConcurrentMonad](_)).unsafeRunSync
+      grpcConfigs.flatMap(createServerConf[ConcurrentMonad]).unsafeRunSync
 
     //////////////////////////////////
     // Client Runtime Configuration //

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/Utils.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/Utils.scala
@@ -489,6 +489,8 @@ object Utils extends CommonUtils {
     import service._
     import handlers.server._
     import higherkindness.mu.rpc.server._
+    import cats.instances.list._
+    import cats.syntax.traverse._
 
     //////////////////////////////////
     // Server Runtime Configuration //
@@ -497,17 +499,17 @@ object Utils extends CommonUtils {
     implicit val muRPCHandler: ServerRPCService[ConcurrentMonad] =
       new ServerRPCService[ConcurrentMonad]
 
-    val grpcConfigs: List[GrpcConfig] = List(
-      AddService(ProtoRPCService.bindService[ConcurrentMonad]),
-      AddService(AvroRPCService.bindService[ConcurrentMonad]),
-      AddService(AvroWithSchemaRPCService.bindService[ConcurrentMonad]),
-      AddService(CompressedProtoRPCService.bindService[ConcurrentMonad]),
-      AddService(CompressedAvroRPCService.bindService[ConcurrentMonad]),
-      AddService(CompressedAvroWithSchemaRPCService.bindService[ConcurrentMonad])
-    )
+    val grpcConfigs: ConcurrentMonad[List[GrpcConfig]] = List(
+      ProtoRPCService.bindService[ConcurrentMonad].map(AddService),
+      AvroRPCService.bindService[ConcurrentMonad].map(AddService),
+      AvroWithSchemaRPCService.bindService[ConcurrentMonad].map(AddService),
+      CompressedProtoRPCService.bindService[ConcurrentMonad].map(AddService),
+      CompressedAvroRPCService.bindService[ConcurrentMonad].map(AddService),
+      CompressedAvroWithSchemaRPCService.bindService[ConcurrentMonad].map(AddService)
+    ).sequence
 
     implicit val grpcServer: GrpcServer[ConcurrentMonad] =
-      createServerConf[ConcurrentMonad](grpcConfigs).unsafeRunSync
+      grpcConfigs.flatMap(createServerConf[ConcurrentMonad](_)).unsafeRunSync
 
     //////////////////////////////////
     // Client Runtime Configuration //

--- a/modules/ssl/src/test/scala/higherkindness/mu/rpc/ssl/Utils.scala
+++ b/modules/ssl/src/test/scala/higherkindness/mu/rpc/ssl/Utils.scala
@@ -72,6 +72,8 @@ object Utils extends CommonUtils {
     import TestsImplicits._
     import service._
     import handlers.server._
+    import cats.instances.list._
+    import cats.syntax.traverse._
 
     //////////////////////////////////
     // Server Runtime Configuration //
@@ -93,14 +95,14 @@ object Utils extends CommonUtils {
         .clientAuth(ClientAuth.REQUIRE)
         .build()
 
-    val grpcConfigs: List[GrpcConfig] = List(
-      SetSslContext(serverSslContext),
-      AddService(AvroRPCService.bindService[ConcurrentMonad]),
-      AddService(AvroWithSchemaRPCService.bindService[ConcurrentMonad])
-    )
+    val grpcConfigs: ConcurrentMonad[List[GrpcConfig]] = List(
+      suspendM(SetSslContext(serverSslContext)),
+      AvroRPCService.bindService[ConcurrentMonad].map(AddService),
+      AvroWithSchemaRPCService.bindService[ConcurrentMonad].map(AddService)
+    ).sequence
 
     implicit val grpcServer: GrpcServer[ConcurrentMonad] =
-      GrpcServer.netty[ConcurrentMonad](SC.port, grpcConfigs).unsafeRunSync
+      grpcConfigs.flatMap(GrpcServer.netty[ConcurrentMonad](SC.port, _)).unsafeRunSync
 
     //////////////////////////////////
     // Client Runtime Configuration //

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -154,6 +154,7 @@ object ProjectPlugin extends AutoPlugin {
     lazy val testingSettings: Seq[Def.Setting[_]] = Seq(
       libraryDependencies ++= Seq(
         %("grpc-testing", V.grpc),
+        %%("cats-effect", V.catsEffect),
         %%("scalacheck") % Test
       )
     )


### PR DESCRIPTION
This PR makes the `bindService` an effect. It also simplifies the server channel utility in testing, making it a resource. The client builder was migrated to a `Resource` so there is no need to close it.

Let me know.