### PR TITLE
Defines the MetricsOps algebra

### DIFF
--- a/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/metrics/MetricsOps.scala
+++ b/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/metrics/MetricsOps.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package higherkindness.mu.rpc.internal.metrics
+import io.grpc.MethodDescriptor.MethodType
+import io.grpc.Status
+
+trait MetricsOps[F[_]] {
+
+  def increaseActiveCalls(classifier: Option[String]): F[Unit]
+
+  def decreaseActiveCalls(classifier: Option[String]): F[Unit]
+
+  def recordMessageSent(method: MethodType, classifier: Option[String]): F[Unit]
+
+  def recordMessageReceived(method: MethodType, status: Status, classifier: Option[String]): F[Unit]
+
+  def recordHeadersTime(method: MethodType, elapsed: Long, classifier: Option[String]): F[Unit]
+
+  def recordTotalTime(
+      method: MethodType,
+      status: Status,
+      elapsed: Long,
+      classifier: Option[String]): F[Unit]
+
+}


### PR DESCRIPTION
I propose the following interceptors. The `recordHeadersTime` will be only used by the clients since the server doesn't receive headers.

Fixes #512

```scala
package higherkindness.mu.rpc.prometheus.server

import higherkindness.mu.rpc.interceptors.GrpcMethodInfo
import io.grpc._

case class MetricsServerInterceptor() extends ServerInterceptor {

  override def interceptCall[Req, Res](
      call: ServerCall[Req, Res],
      requestHeaders: Metadata,
      next: ServerCallHandler[Req, Res]): ServerCall.Listener[Req] = {

    val method: GrpcMethodInfo = GrpcMethodInfo(call.getMethodDescriptor)

    val metricsCall: MetricsServerCall[Req, Res] =
      MetricsServerCall[Req, Res](call, method)

    MetricsServerCallListener[Req](next.startCall(metricsCall, requestHeaders), method)
  }
}

case class MetricsServerCall[Req, Res](serverCall: ServerCall[Req, Res], method: GrpcMethodInfo)
    extends ForwardingServerCall.SimpleForwardingServerCall[Req, Res](serverCall) {

  // Start time

  override def close(status: Status, responseHeaders: Metadata): Unit = {
    // MetricsOps.recordTotalTime
    super.close(status, responseHeaders)
  }

  override def sendMessage(message: Res): Unit = {
    // MetricsOps.recordMessageSent
    super.sendMessage(message)
  }
}

case class MetricsServerCallListener[Req](
    delegate: ServerCall.Listener[Req],
    method: GrpcMethodInfo)
    extends ForwardingServerCallListener[Req] {

  override def onMessage(request: Req): Unit = {
    // MetricsOps.recordMessageReceived && MetricsOps.increaseActiveCalls
    super.onMessage(request)
  }

  override def onComplete(): Unit = {
    // MetricsOps.decreaseActiveCalls
    super.onComplete()
  }
}
```

```scala
package higherkindness.mu.rpc.prometheus.client

import higherkindness.mu.rpc.interceptors.GrpcMethodInfo
import io.grpc._

case class MetricsClientInterceptor() extends ClientInterceptor {

  override def interceptCall[Req, Res](
      methodDescriptor: MethodDescriptor[Req, Res],
      callOptions: CallOptions,
      channel: Channel): ClientCall[Req, Res] = {

    val methodInfo: GrpcMethodInfo = GrpcMethodInfo(methodDescriptor)

    MetricsClientCall[Req, Res](channel.newCall(methodDescriptor, callOptions), methodInfo)
  }
}

case class MetricsClientCall[Req, Res](
    clientCall: ClientCall[Req, Res],
    methodInfo: GrpcMethodInfo)
    extends ForwardingClientCall.SimpleForwardingClientCall[Req, Res](clientCall) {

  override def start(responseListener: ClientCall.Listener[Res], headers: Metadata): Unit = {
    // MetricsOps.increaseActiveCalls
    val listener: MetricsClientCallListener[Res] =
      MetricsClientCallListener(responseListener, methodInfo)
    super.start(listener, headers)
  }

  override def sendMessage(requestMessage: Req): Unit = {
    // MetricsOps.recordMessageSent
    super.sendMessage(requestMessage)
  }
}

case class MetricsClientCallListener[Res](
    delegate: ClientCall.Listener[Res],
    methodInfo: GrpcMethodInfo)
    extends ForwardingClientCallListener[Res] {

  // start time

  override def onHeaders(headers: Metadata): Unit = {
    // MetricsOps.recordHeadersTime
    super.onHeaders(headers)
  }

  override def onMessage(responseMessage: Res): Unit = {
    // MetricsOps.recordTotalTime && MetricsOps.recordMessageReceived
    super.onMessage(responseMessage)
  }

  override def onClose(status: Status, metadata: Metadata): Unit = {
    // MetricsOps.decreaseActiveCalls
    super.onClose(status, metadata)
  }
}
```