### PR TITLE
Disables dependencies plugin

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -32,8 +32,9 @@ object ProjectPlugin extends AutoPlugin {
       val frees: String              = "0.8.2"
       val fs2: String                = "1.0.2"
       val fs2Grpc: String            = "0.4.0-M3"
-      val jodaTime: String           = "2.10.1"
       val grpc: String               = "1.18.0"
+      val jodaTime: String           = "2.10.1"
+      val kindProjector: String      = "0.9.9"
       val log4s: String              = "1.6.1"
       val logback: String            = "1.2.3"
       val monix: String              = "3.0.0-RC2"
@@ -302,6 +303,7 @@ object ProjectPlugin extends AutoPlugin {
       Tut / scalacOptions -= "-Ywarn-unused-import",
       compileOrder in Compile := CompileOrder.JavaThenScala,
       coverageFailOnMinimum := false,
+      addCompilerPlugin(%%("kind-projector", V.kindProjector) cross CrossVersion.binary),
       addCompilerPlugin(%%("paradise", V.paradise) cross CrossVersion.full),
       libraryDependencies ++= Seq(
         %%("scalatest") % "test",

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -8,6 +8,7 @@ import sbtorgpolicies.OrgPoliciesPlugin.autoImport._
 import sbtorgpolicies.model._
 import sbtorgpolicies.templates._
 import sbtorgpolicies.templates.badges._
+import sbtorgpolicies.runnable.syntax._
 import sbtrelease.ReleasePlugin.autoImport._
 import scoverage.ScoverageKeys._
 
@@ -351,7 +352,11 @@ object ProjectPlugin extends AutoPlugin {
         ),
         ScalafmtFileType,
         TravisFileType(crossScalaVersions.value, orgScriptCICommandKey, orgAfterCISuccessCommandKey)
-      )
+      ),
+      orgAfterCISuccessTaskListSetting := List(
+        orgPublishReleaseTask.asRunnableItem(allModules = true, aggregated = false, crossScalaVersions = true),
+        orgUpdateDocFiles.asRunnableItem
+      ) ++ guard(!version.value.endsWith("-SNAPSHOT"))(defaultPublishMicrosite)
     )
   // format: ON
 }

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -303,8 +303,10 @@ object ProjectPlugin extends AutoPlugin {
       Tut / scalacOptions -= "-Ywarn-unused-import",
       compileOrder in Compile := CompileOrder.JavaThenScala,
       coverageFailOnMinimum := false,
-      addCompilerPlugin(%%("kind-projector", V.kindProjector) cross CrossVersion.binary),
       addCompilerPlugin(%%("paradise", V.paradise) cross CrossVersion.full),
+      addCompilerPlugin(%%("kind-projector", V.kindProjector) cross CrossVersion.binary),
+      // This is needed to prevent the eviction regarding the version of kind-projector injected by org-policies:
+      libraryDependencies ~= (_.filterNot(m => m.name == "kind-projector" && m.revision == "0.9.7")),
       libraryDependencies ++= Seq(
         %%("scalatest") % "test",
         %("slf4j-nop")  % Test

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += Resolver.sonatypeRepo("releases")
 resolvers += Resolver.sonatypeRepo("snapshots")
 
-addSbtPlugin("com.47deg"          % "sbt-org-policies" % "0.9.4")
+addSbtPlugin("com.47deg"          % "sbt-org-policies" % "0.9.4" exclude("org.spire-math", "kind-projector"))
 addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"    % "0.9.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"          % "0.3.4")
 


### PR DESCRIPTION
This PR overrides the default behavior provided by org-policies. Instead, when Travis is succeeded:

* Release
* Update docs files
* Publish microsite