### PR TITLE
Fixes typo in the documentation of Dropwizard metrics

### DIFF
--- a/modules/metrics/dropwizard/src/main/scala/metricsops/DropWizardMetricsOps.scala
+++ b/modules/metrics/dropwizard/src/main/scala/metricsops/DropWizardMetricsOps.scala
@@ -20,8 +20,8 @@
  * The list of registered metrics contains:
  *
  * {prefix}.{classifier}.active.calls - Counter
- * {prefix}.{classifier}.{serviceName}.{methodName}.{methodType}.messages.sent - Counter
- * {prefix}.{classifier}.{serviceName}.{methodName}.{methodType}.messages.received - Counter
+ * {prefix}.{classifier}.{serviceName}.{methodName}.messages.sent - Counter
+ * {prefix}.{classifier}.{serviceName}.{methodName}.messages.received - Counter
  * {prefix}.{classifier}.calls.header - Timer
  * {prefix}.{classifier}.calls.total - Timer
  * {prefix}.{classifier}.{methodType} - Timer


### PR DESCRIPTION
This pull request fixes a typo in the documentation about the Dropwizard metrics. The messages sent and received were including the `methodType` in the metric name, but we weren't including that info in the implementation.