### PR TITLE
Fixes some package names and some refactors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -149,6 +149,13 @@ lazy val `prometheus-client` = project
   .settings(moduleName := "mu-rpc-prometheus-client")
   .settings(prometheusClientSettings)
 
+lazy val `prometheus` = project
+  .in(file("modules/metrics/prometheus"))
+  .dependsOn(`internal-core`)
+  .dependsOn(testing % "test->test")
+  .settings(moduleName := "mu-rpc-prometheus")
+  .settings(prometheusMetricsSettings)
+
 ////////////////////
 //// DROPWIZARD ////
 ////////////////////
@@ -389,6 +396,7 @@ lazy val allModules: Seq[ProjectReference] = Seq(
   `dropwizard-server`,
   `dropwizard-client`,
   `dropwizard`,
+  `prometheus`,
   testing,
   ssl,
   `idlgen-core`,

--- a/docs/src/main/tut/metrics-reporting.md
+++ b/docs/src/main/tut/metrics-reporting.md
@@ -65,7 +65,7 @@ import service._
 
 object InterceptingServerCalls extends CommonRuntime {
 
-  import higherkindness.mu.rpc.interceptors.implicits._
+  import higherkindness.mu.rpc.server.interceptors.implicits._
 
   lazy val cr: CollectorRegistry = new CollectorRegistry()
   lazy val monitorInterceptor = MonitoringServerInterceptor(

--- a/modules/channel/src/main/scala/higherkindness/mu/rpc/channel/metrics/MetricsChannelInterceptor.scala
+++ b/modules/channel/src/main/scala/higherkindness/mu/rpc/channel/metrics/MetricsChannelInterceptor.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration._
 
 case class MetricsChannelInterceptor[F[_]: Effect: Clock](
     metricsOps: MetricsOps[F],
-    classifier: Option[String])
+    classifier: Option[String] = None)
     extends ClientInterceptor {
 
   override def interceptCall[Req, Res](

--- a/modules/metrics/dropwizard/src/main/scala/higherkindness/mu/rpc/dropwizard/DropWizardMetrics.scala
+++ b/modules/metrics/dropwizard/src/main/scala/higherkindness/mu/rpc/dropwizard/DropWizardMetrics.scala
@@ -14,6 +14,18 @@
  * limitations under the License.
  */
 
+package higherkindness.mu.rpc.dropwizard
+
+import java.util.concurrent.TimeUnit
+
+import cats.effect.Sync
+import com.codahale.metrics.MetricRegistry
+import higherkindness.mu.rpc.internal.interceptors.GrpcMethodInfo
+import higherkindness.mu.rpc.internal.metrics.MetricsOps
+import higherkindness.mu.rpc.internal.metrics.MetricsOps._
+import io.grpc.MethodDescriptor.MethodType._
+import io.grpc.Status
+
 /*
  * [[MetricsOps]] algebra able to record Dropwizard metrics.
  *
@@ -27,7 +39,7 @@
  * {prefix}.{classifier}.{methodType} - Timer
  * {prefix}.{classifier}.{status} - Timer
  *
- * {methodType} can be one of the following:
+ * {methodType} can be one of the following:
  *    - "unary-methods"
  *    - "client-streaming-methods"
  *    - "server-streaming-methods"
@@ -47,27 +59,14 @@
  *    - "unreachable-error-statuses"
  *
  */
-
-package metricsops
-
-import java.util.concurrent.TimeUnit
-
-import cats.effect.Sync
-import com.codahale.metrics.MetricRegistry
-import higherkindness.mu.rpc.internal.interceptors.GrpcMethodInfo
-import higherkindness.mu.rpc.internal.metrics.MetricsOps
-import higherkindness.mu.rpc.internal.metrics.MetricsOps._
-import io.grpc.MethodDescriptor.MethodType._
-import io.grpc.Status
-
-object DropWizardMetricsOps {
+object DropWizardMetrics {
 
   sealed trait GaugeType
   case object Timer   extends GaugeType
   case object Counter extends GaugeType
 
   def apply[F[_]](registry: MetricRegistry, prefix: String = "higherkinderness.mu")(
-      implicit F: Sync[F]) = new MetricsOps[F] {
+      implicit F: Sync[F]): MetricsOps[F] = new MetricsOps[F] {
 
     override def increaseActiveCalls(
         methodInfo: GrpcMethodInfo,

--- a/modules/metrics/dropwizard/src/test/scala/higherkindness/mu/rpc/dropwizard/DropWizardMetricsOpsTests.scala
+++ b/modules/metrics/dropwizard/src/test/scala/higherkindness/mu/rpc/dropwizard/DropWizardMetricsOpsTests.scala
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package metricsops
+package higherkindness.mu.rpc.dropwizard
 
 import cats.effect.IO
 import cats.implicits._
 import com.codahale.metrics.MetricRegistry
+import higherkindness.mu.rpc.dropwizard.DropWizardMetrics._
 import higherkindness.mu.rpc.internal.interceptors.GrpcMethodInfo
-import DropWizardMetricsOps._
 import higherkindness.mu.rpc.internal.metrics.MetricsOps
 import io.grpc.MethodDescriptor.MethodType
 import io.grpc.Status
@@ -30,7 +30,7 @@ import org.scalacheck.Prop._
 
 import scala.collection.JavaConverters._
 
-object DropWizardMetricsOpsTests extends Properties("DropWizardMetrics") {
+object DropWizardMetricsTests extends Properties("DropWizardMetrics") {
 
   val prefix     = "testPrefix"
   val classifier = "classifier"
@@ -113,7 +113,7 @@ object DropWizardMetricsOpsTests extends Properties("DropWizardMetrics") {
     forAllNoShrink(methodInfoGen, Gen.chooseNum[Int](1, 10)) {
       (methodInfo: GrpcMethodInfo, numberOfCalls: Int) =>
         val registry        = new MetricRegistry()
-        val metrics         = DropWizardMetricsOps[IO](registry, prefix)
+        val metrics         = DropWizardMetrics[IO](registry, prefix)
         val activeCallsName = s"$prefix.$classifier.active.calls"
 
         (for {
@@ -142,7 +142,7 @@ object DropWizardMetricsOpsTests extends Properties("DropWizardMetrics") {
     forAllNoShrink(methodInfoGen, Gen.chooseNum[Int](1, 10)) {
       (methodInfo: GrpcMethodInfo, numberOfCalls: Int) =>
         val registry = new MetricRegistry()
-        val metrics  = DropWizardMetricsOps[IO](registry, prefix)
+        val metrics  = DropWizardMetrics[IO](registry, prefix)
         val messagesSentName =
           s"$prefix.$classifier.${methodInfo.serviceName}.${methodInfo.methodName}.messages.sent"
 
@@ -161,7 +161,7 @@ object DropWizardMetricsOpsTests extends Properties("DropWizardMetrics") {
     forAllNoShrink(methodInfoGen, Gen.chooseNum[Int](1, 10)) {
       (methodInfo: GrpcMethodInfo, numberOfCalls: Int) =>
         val registry = new MetricRegistry()
-        val metrics  = DropWizardMetricsOps[IO](registry, prefix)
+        val metrics  = DropWizardMetrics[IO](registry, prefix)
         val messagesReceivedName =
           s"$prefix.$classifier.${methodInfo.serviceName}.${methodInfo.methodName}.messages.received"
 
@@ -180,7 +180,7 @@ object DropWizardMetricsOpsTests extends Properties("DropWizardMetrics") {
     forAllNoShrink(methodInfoGen, Gen.chooseNum[Int](1, 10), Gen.chooseNum(100, 1000)) {
       (methodInfo: GrpcMethodInfo, numberOfCalls: Int, elapsed: Int) =>
         val registry    = new MetricRegistry()
-        val metrics     = DropWizardMetricsOps[IO](registry, prefix)
+        val metrics     = DropWizardMetrics[IO](registry, prefix)
         val headersName = s"$prefix.$classifier.calls.header"
 
         performAndCheckMetrics(
@@ -198,7 +198,7 @@ object DropWizardMetricsOpsTests extends Properties("DropWizardMetrics") {
     forAllNoShrink(methodInfoGen, Gen.chooseNum[Int](1, 10), statusGen) {
       (methodInfo: GrpcMethodInfo, numberOfCalls: Int, status: Status) =>
         val registry = new MetricRegistry()
-        val metrics  = DropWizardMetricsOps[IO](registry, prefix)
+        val metrics  = DropWizardMetrics[IO](registry, prefix)
 
         (1 to numberOfCalls).toList
           .map(_ => metrics.recordTotalTime(methodInfo, status, 1L, Some(classifier)))

--- a/modules/metrics/prometheus/src/main/scala/higherkindness/mu/rpc/prometheus/PrometheusMetrics.scala
+++ b/modules/metrics/prometheus/src/main/scala/higherkindness/mu/rpc/prometheus/PrometheusMetrics.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package higherkindness.mu.rpc.prometheus
+
+import io.prometheus.client.CollectorRegistry
+import higherkindness.mu.rpc.internal.metrics.MetricsOps
+
+object PrometheusMetrics {
+
+  def apply[F[_]](cr: CollectorRegistry, prefix: String = "higherkinderness.mu"): F[MetricsOps[F]] = ???
+
+}

--- a/modules/prometheus/server/src/test/scala/higherkindness/mu/rpc/prometheus/server/InterceptorsRuntime.scala
+++ b/modules/prometheus/server/src/test/scala/higherkindness/mu/rpc/prometheus/server/InterceptorsRuntime.scala
@@ -34,7 +34,7 @@ case class InterceptorsRuntime(
   import handlers.server._
   import handlers.client._
   import higherkindness.mu.rpc.server._
-  import higherkindness.mu.rpc.interceptors.implicits._
+  import higherkindness.mu.rpc.server.interceptors.implicits._
   import cats.instances.list._
   import cats.syntax.traverse._
 

--- a/modules/server/src/main/scala/higherkindness/mu/rpc/server/interceptors/implicits.scala
+++ b/modules/server/src/main/scala/higherkindness/mu/rpc/server/interceptors/implicits.scala
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-package higherkindness.mu.rpc
-package interceptors
+package higherkindness.mu.rpc.server.interceptors
 
 import io.grpc.{ServerInterceptor, ServerInterceptors, ServerServiceDefinition}
 

--- a/modules/server/src/main/scala/higherkindness/mu/rpc/server/metrics/MetricsServerInterceptor.scala
+++ b/modules/server/src/main/scala/higherkindness/mu/rpc/server/metrics/MetricsServerInterceptor.scala
@@ -28,7 +28,7 @@ import scala.concurrent.duration._
 
 case class MetricsServerInterceptor[F[_]: Clock](
     metricsOps: MetricsOps[F],
-    classifier: Option[String])(implicit E: Effect[F])
+    classifier: Option[String] = None)(implicit E: Effect[F])
     extends ServerInterceptor {
 
   override def interceptCall[Req, Res](

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/server/metrics/MetricsServerInterceptorTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/server/metrics/MetricsServerInterceptorTests.scala
@@ -21,10 +21,10 @@ import cats.effect.{Clock, IO, Resource}
 import cats.syntax.apply._
 import higherkindness.mu.rpc.common._
 import higherkindness.mu.rpc.common.util.FakeClock
-import higherkindness.mu.rpc.interceptors.implicits._
 import higherkindness.mu.rpc.internal.interceptors.GrpcMethodInfo
 import higherkindness.mu.rpc.internal.metrics.{MetricsOps, MetricsOpsRegister}
 import higherkindness.mu.rpc.protocol._
+import higherkindness.mu.rpc.server.interceptors.implicits._
 import higherkindness.mu.rpc.testing.servers._
 import io.grpc.MethodDescriptor.MethodType
 import io.grpc.Status

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -154,6 +154,12 @@ object ProjectPlugin extends AutoPlugin {
       )
     )
 
+    lazy val prometheusMetricsSettings: Seq[Def.Setting[_]] = Seq(
+      libraryDependencies ++= Seq(
+        %("prometheus", V.prometheus)
+      )
+    )
+
     lazy val dropwizardMetricsSettings: Seq[Def.Setting[_]] = Seq(
       libraryDependencies ++= Seq(
         "io.dropwizard.metrics" % "metrics-core" % V.dropwizard


### PR DESCRIPTION
This PR:
* Adds a new module that will contain the prometheus metrics impl
* Fixes dropwizard package names
* Moves the interceptor implicits for the server to the server module