### PR TITLE
Upgrades Build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -434,3 +434,7 @@ lazy val docs = project
   .settings(micrositeSettings: _*)
   .settings(noPublishSettings: _*)
   .enablePlugins(MicrositesPlugin)
+
+onLoad in Global := { s =>
+  "dependencyUpdates" :: s
+}

--- a/build.sbt
+++ b/build.sbt
@@ -434,7 +434,3 @@ lazy val docs = project
   .settings(micrositeSettings: _*)
   .settings(noPublishSettings: _*)
   .enablePlugins(MicrositesPlugin)
-
-onLoad in Global := { s =>
-  "dependencyUpdates" :: s
-}

--- a/docs/src/main/tut/patterns.md
+++ b/docs/src/main/tut/patterns.md
@@ -203,7 +203,7 @@ Thanks to `withServerChannel` from the package `mu.rpc.testing.servers`, you wil
 import cats.effect.Resource
 import higherkindness.mu.rpc.testing.servers.withServerChannel
 import io.grpc.{ManagedChannel, ServerServiceDefinition}
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import org.scalatest._
 import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll

--- a/modules/idlgen/core/src/test/scala/higherkindness/mu/rpc/idlgen/SrcGenTests.scala
+++ b/modules/idlgen/core/src/test/scala/higherkindness/mu/rpc/idlgen/SrcGenTests.scala
@@ -19,7 +19,7 @@ package higherkindness.mu.rpc.idlgen
 import higherkindness.mu.rpc.common.RpcBaseTestSuite
 import higherkindness.mu.rpc.idlgen.AvroScalaGeneratorArbitrary._
 import higherkindness.mu.rpc.idlgen.avro._
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import org.scalacheck.Prop.forAll
 
 class SrcGenTests extends RpcBaseTestSuite with Checkers {

--- a/modules/internal/src/test/scala/higherkindness/mu/rpc/internal/util/BigDecimalUtilTests.scala
+++ b/modules/internal/src/test/scala/higherkindness/mu/rpc/internal/util/BigDecimalUtilTests.scala
@@ -22,7 +22,7 @@ import org.scalacheck.Gen.Choose
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest._
 import org.scalacheck.Prop._
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 
 class BigDecimalUtilTests extends WordSpec with Matchers with Checkers {
 

--- a/modules/internal/src/test/scala/higherkindness/mu/rpc/internal/util/EncoderUtilTest.scala
+++ b/modules/internal/src/test/scala/higherkindness/mu/rpc/internal/util/EncoderUtilTest.scala
@@ -20,7 +20,7 @@ package util
 
 import org.scalatest._
 import org.scalacheck.Prop._
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 
 class EncoderUtilTest extends WordSpec with Matchers with Checkers {
 

--- a/modules/internal/src/test/scala/higherkindness/mu/rpc/internal/util/JavaTimeUtilTests.scala
+++ b/modules/internal/src/test/scala/higherkindness/mu/rpc/internal/util/JavaTimeUtilTests.scala
@@ -24,7 +24,7 @@ import com.fortysevendeg.scalacheck.datetime.instances.jdk8._
 import com.fortysevendeg.scalacheck.datetime.GenDateTime._
 import org.scalatest._
 import org.scalacheck.Prop._
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 
 class JavaTimeUtilTests extends WordSpec with Matchers with Checkers {
 

--- a/modules/marshallers/jodatime/src/test/scala/higherkindness/mu/rpc/internal/util/JodaTimeUtilTest.scala
+++ b/modules/marshallers/jodatime/src/test/scala/higherkindness/mu/rpc/internal/util/JodaTimeUtilTest.scala
@@ -24,7 +24,7 @@ import com.fortysevendeg.scalacheck.datetime.GenDateTime.genDateTimeWithinRange
 import higherkindness.mu.rpc.jodatime.util.JodaTimeUtil
 import org.scalatest._
 import org.scalacheck.Prop._
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 
 class JodaTimeUtilTest extends WordSpec with Matchers with Checkers {
 

--- a/modules/marshallers/jodatime/src/test/scala/higherkindness/mu/rpc/protocol/RPCJodaLocalDateTests.scala
+++ b/modules/marshallers/jodatime/src/test/scala/higherkindness/mu/rpc/protocol/RPCJodaLocalDateTests.scala
@@ -29,7 +29,7 @@ import io.grpc.{ManagedChannel, ServerServiceDefinition}
 import org.scalacheck.Arbitrary
 import org.scalatest._
 import org.scalacheck.Prop._
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 
 class RPCJodaLocalDateTests extends RpcBaseTestSuite with BeforeAndAfterAll with Checkers {
 

--- a/modules/marshallers/jodatime/src/test/scala/higherkindness/mu/rpc/protocol/RPCJodaLocalDateTimeTests.scala
+++ b/modules/marshallers/jodatime/src/test/scala/higherkindness/mu/rpc/protocol/RPCJodaLocalDateTimeTests.scala
@@ -29,7 +29,7 @@ import io.grpc.{ManagedChannel, ServerServiceDefinition}
 import org.scalacheck.Arbitrary
 import org.scalatest._
 import org.scalacheck.Prop._
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 
 class RPCJodaLocalDateTimeTests extends RpcBaseTestSuite with BeforeAndAfter with Checkers {
 

--- a/modules/metrics/prometheus/src/main/scala/higherkindness/mu/rpc/prometheus/PrometheusMetrics.scala
+++ b/modules/metrics/prometheus/src/main/scala/higherkindness/mu/rpc/prometheus/PrometheusMetrics.scala
@@ -21,6 +21,7 @@ import higherkindness.mu.rpc.internal.metrics.MetricsOps
 
 object PrometheusMetrics {
 
-  def apply[F[_]](cr: CollectorRegistry, prefix: String = "higherkinderness.mu"): F[MetricsOps[F]] = ???
+  def apply[F[_]](cr: CollectorRegistry, prefix: String = "higherkinderness.mu"): F[MetricsOps[F]] =
+    ???
 
 }

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCBigDecimalTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCBigDecimalTests.scala
@@ -27,7 +27,7 @@ import higherkindness.mu.rpc.internal.encoders.pbd.bigDecimal._
 import higherkindness.mu.rpc.protocol.Utils._
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Prop._
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.{tag, Nat}
 import shapeless.tag.@@
 

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCJavaTimeTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCJavaTimeTests.scala
@@ -32,7 +32,7 @@ import higherkindness.mu.rpc.protocol.Utils._
 import org.scalacheck.Arbitrary
 import org.scalatest._
 import org.scalacheck.Prop._
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 
 class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Checkers {
 

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCProtoProducts.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCProtoProducts.scala
@@ -23,7 +23,7 @@ import higherkindness.mu.rpc.common._
 import higherkindness.mu.rpc.protocol.Utils._
 import org.scalatest._
 import org.scalacheck.Prop._
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 
 class RPCProtoProducts extends RpcBaseTestSuite with BeforeAndAfterAll with Checkers {
 

--- a/modules/testing/src/test/scala/higherkindness/mu/rpc/testing/MethodsTests.scala
+++ b/modules/testing/src/test/scala/higherkindness/mu/rpc/testing/MethodsTests.scala
@@ -19,7 +19,7 @@ package testing
 
 import org.scalacheck.Gen
 import org.scalatest._
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import org.scalacheck.Prop._
 
 class MethodsTests extends WordSpec with Matchers with Checkers {

--- a/modules/testing/src/test/scala/higherkindness/mu/rpc/testing/ServersTests.scala
+++ b/modules/testing/src/test/scala/higherkindness/mu/rpc/testing/ServersTests.scala
@@ -19,7 +19,7 @@ package testing
 
 import io.grpc.{ServerCall, ServerCallHandler, ServerServiceDefinition}
 import org.scalatest._
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import org.scalacheck.Prop._
 
 import scala.collection.JavaConverters._

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -320,6 +320,7 @@ object ProjectPlugin extends AutoPlugin {
       Tut / scalacOptions -= "-Ywarn-unused-import",
       compileOrder in Compile := CompileOrder.JavaThenScala,
       coverageFailOnMinimum := false,
+      resolvers ++= Seq(Resolver.sonatypeRepo("releases"), Resolver.sonatypeRepo("snapshots")),
       addCompilerPlugin(%%("paradise", V.paradise) cross CrossVersion.full),
       addCompilerPlugin(%%("kind-projector", V.kindProjector) cross CrossVersion.binary),
       libraryDependencies ++= Seq(

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -272,9 +272,7 @@ object ProjectPlugin extends AutoPlugin {
     )
 
     lazy val docsSettings: Seq[Def.Setting[_]] = Seq(
-      libraryDependencies ++= Seq(
-        %%("scalatest", V.scalatest) % "tut"
-      ),
+      libraryDependencies += %%("scalatest", V.scalatest),
       scalacOptions in Tut ~= (_ filterNot Set("-Ywarn-unused-import", "-Xlint").contains)
     )
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -30,23 +30,26 @@ object ProjectPlugin extends AutoPlugin {
       val catsEffect: String         = "1.2.0"
       val circe: String              = "0.11.1"
       val frees: String              = "0.8.2"
-      val fs2: String                = "1.0.3"
+      val fs2: String                = "1.0.4"
       val fs2Grpc: String            = "0.4.0-M6"
       val grpc: String               = "1.18.0"
       val jodaTime: String           = "2.10.1"
       val kindProjector: String      = "0.9.9"
-      val log4s: String              = "1.6.1"
+      val log4s: String              = "1.7.0"
       val logback: String            = "1.2.3"
       val monix: String              = "3.0.0-RC2"
       val monocle: String            = "1.5.1-cats"
       val nettySSL: String           = "2.0.20.Final"
       val paradise: String           = "2.1.1"
-      val pbdirect: String           = "0.2.0"
+      val pbdirect: String           = "0.2.1"
       val prometheus: String         = "0.6.0"
-      val pureconfig: String         = "0.10.1"
+      val pureconfig: String         = "0.10.2"
       val reactiveStreams: String    = "1.0.2"
       val scala: String              = "2.12.8"
       val scalacheckToolbox: String  = "0.2.5"
+      val scalamockScalatest: String = "3.6.0"
+      val scalatest: String          = "3.0.6"
+      val slf4j: String              = "1.7.26"
       val dropwizard: String         = "4.0.5"
     }
 
@@ -73,7 +76,7 @@ object ProjectPlugin extends AutoPlugin {
     lazy val internalMonixSettings: Seq[Def.Setting[_]] = Seq(
       libraryDependencies ++= Seq(
         %%("monix", V.monix),
-        "org.reactivestreams" % "reactive-streams" % V.reactiveStreams,
+        "org.reactivestreams"    % "reactive-streams" % V.reactiveStreams,
         %%("scalamockScalatest") % Test
       )
     )
@@ -270,7 +273,7 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val docsSettings: Seq[Def.Setting[_]] = Seq(
       libraryDependencies ++= Seq(
-        %%("scalatest") % "tut"
+        %%("scalatest", V.scalatest) % "tut"
       ),
       scalacOptions in Tut ~= (_ filterNot Set("-Ywarn-unused-import", "-Xlint").contains)
     )
@@ -319,11 +322,9 @@ object ProjectPlugin extends AutoPlugin {
       coverageFailOnMinimum := false,
       addCompilerPlugin(%%("paradise", V.paradise) cross CrossVersion.full),
       addCompilerPlugin(%%("kind-projector", V.kindProjector) cross CrossVersion.binary),
-      // This is needed to prevent the eviction regarding the version of kind-projector injected by org-policies:
-      libraryDependencies ~= (_.filterNot(m => m.name == "kind-projector" && m.revision == "0.9.7")),
       libraryDependencies ++= Seq(
-        %%("scalatest") % "test",
-        %("slf4j-nop")  % Test
+        %%("scalatest", V.scalatest) % "test",
+        %("slf4j-nop", V.slf4j)      % Test
       )
     ) ++ Seq(
       // sbt-org-policies settings:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,10 @@
 resolvers += Resolver.sonatypeRepo("releases")
 resolvers += Resolver.sonatypeRepo("snapshots")
 
-addSbtPlugin("com.47deg"          % "sbt-org-policies" % "0.9.4" exclude("org.spire-math", "kind-projector"))
+addSbtPlugin("com.47deg"          % "sbt-org-policies" % "0.11.1")
+addSbtPlugin("com.47deg"          % "sbt-microsites"   % "0.9.0")
 addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"    % "0.9.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"          % "0.3.4")
+addSbtPlugin("com.timushev.sbt"   % "sbt-updates"      % "0.4.0")
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value


### PR DESCRIPTION
This PR:

* Upgrades sbt-org-policies.
* Adds the latest version fo sbt-microsites
* Bumps up some other dependencies like fs2, pbdirect or scalatest, among others.
* The new version of scalatest deprecates some type aliases that I'm replacing for the final version in this PR.
* Adds the `sbt-updates` plugin to be able to run the `dependencyUpdates` command.