### PR TITLE
Enables benchmarks for the previous Mu version

### DIFF
--- a/benchmarks/run-benchmark
+++ b/benchmarks/run-benchmark
@@ -18,5 +18,5 @@ name = ARGV[0]
 date = Time.now.strftime("%Y-%m-%d")
 
 exec("mkdir -p benchmarks/results/#{date}")
-exec("sbt benchmarks-vnext/clean 'benchmarks-vnext/jmh:run -o ../results/#{date}/#{name}-Next.txt  -i 10 -wi 10 -f 2 -t 1 -r 1 -w 1 mu.rpc.benchmarks.#{name}'")
-exec("sbt benchmarks-vprev/clean 'benchmarks-vprev/jmh:run -o ../results/#{date}/#{name}-Prev.txt  -i 10 -wi 10 -f 2 -t 1 -r 1 -w 1 mu.rpc.benchmarks.#{name}'")
+exec("sbt benchmarks-vnext/clean 'benchmarks-vnext/jmh:run -o ../results/#{date}/#{name}-Next.txt  -i 10 -wi 10 -f 2 -t 1 -r 1 -w 1 mu.rpc.higherkindness.mu.rpc.benchmarks.#{name}'")
+exec("sbt benchmarks-vprev/clean 'benchmarks-vprev/jmh:run -o ../results/#{date}/#{name}-Prev.txt  -i 10 -wi 10 -f 2 -t 1 -r 1 -w 1 mu.rpc.higherkindness.mu.rpc.benchmarks.#{name}'")

--- a/benchmarks/run-benchmarks-all
+++ b/benchmarks/run-benchmarks-all
@@ -2,7 +2,7 @@
 
 Dir.chdir(File.absolute_path(File.join(File.dirname(__FILE__), "..")))
 
-Dir.entries("benchmarks/shared/src/main/scala").each do |f|
+Dir.entries("benchmarks/shared/src/main/scala/higherkindness/mu/rpc/benchmarks").each do |f|
   if f =~ /^([^.]+)\.scala$/
     name = $1
     system("./benchmarks/run-benchmark #{name}") if name !~ /package/

--- a/build.sbt
+++ b/build.sbt
@@ -208,22 +208,17 @@ lazy val `idlgen-sbt` = project
 //// BENCHMARKS ////
 ////////////////////
 
-lazy val lastReleasedV = "0.15.1"
+lazy val lastReleasedV = "0.17.2"
 
 lazy val `benchmarks-vprev` = project
   .in(file("benchmarks/vprev"))
-  // TODO: temporarily disabled until the project is migrated
-//  .settings(
-//    libraryDependencies ++= Seq(
-//      "io.higherkindness" %% "mu-rpc-channel" % lastReleasedV,
-//      "io.higherkindness" %% "mu-rpc-server"      % lastReleasedV,
-//      "io.higherkindness" %% "mu-rpc-testing"     % lastReleasedV
-//    )
-//  )
-  // TODO: remove dependsOn and uncomment the lines above
-  .dependsOn(channel)
-  .dependsOn(server)
-  .dependsOn(testing)
+  .settings(
+    libraryDependencies ++= Seq(
+      "io.higherkindness" %% "mu-rpc-channel" % lastReleasedV,
+      "io.higherkindness" %% "mu-rpc-server"  % lastReleasedV,
+      "io.higherkindness" %% "mu-rpc-testing" % lastReleasedV
+    )
+  )
   .settings(coverageEnabled := false)
   .settings(moduleName := "mu-benchmarks-vprev")
   .settings(crossSettings)


### PR DESCRIPTION
... in order to be able to compare the current master branch code and the previously released version (0.17.2 in this case).

See https://github.com/higherkindness/mu/tree/master/benchmarks#benchmarks to know more about how to run them.