### PR TITLE
Improves how the params are received in the annotation

### DIFF
--- a/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/serviceImpl.scala
+++ b/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/serviceImpl.scala
@@ -170,6 +170,15 @@ object serviceImpl {
         case d: DefDef => d
       } partition (_.rhs.isEmpty)
 
+      val annotationParams: List[Either[String, (String, String)]] = c.prefix.tree match {
+        case q"new service(..$seq)" =>
+          seq.toList.map {
+            case q"$pName = $pValue" => Right((pName.toString(), pValue.toString()))
+            case param               => Left(param.toString())
+          }
+        case _ => Nil
+      }
+
       private val compressionType: Tree =
         annotationParam(1, "compressionType") {
           case "Identity" => q"None"
@@ -178,13 +187,13 @@ object serviceImpl {
 
       private val OptionString = "Some\\(\"(.+)\"\\)".r
 
-      private val namespace: String =
+      private val namespacePrefix: String =
         annotationParam(2, "namespace") {
           case OptionString(s) => s"$s."
           case "None"          => ""
         }.getOrElse("")
 
-      private val fullyServiceName = namespace + serviceName.toString
+      private val fullyServiceName = namespacePrefix + serviceName.toString
 
       private val methodNameStyle: MethodNameStyle =
         annotationParam(3, "methodNameStyle") {
@@ -201,7 +210,6 @@ object serviceImpl {
         RpcRequest(
           Operation(d.name, TypeTypology(p.tpt), TypeTypology(d.tpt)),
           compressionType,
-          namespace,
           methodNameStyle
         )
 
@@ -315,16 +323,14 @@ object serviceImpl {
 
       private def annotationParam[A](pos: Int, name: String)(
           pf: PartialFunction[String, A]): Option[A] = {
-        val rawValue: Option[String] = c.prefix.tree match {
-          case q"new service(..$list)" =>
-            list
-              .collectFirst {
-                case q"$pName = $pValue" if pName.toString == name => pValue.toString
-              }
-              .orElse(list.lift(pos).map(_.toString()))
-          case _ => None
-        }
-        rawValue.map { s =>
+
+        def findNamed: Option[Either[String, (String, String)]] =
+          annotationParams.find(_.exists(_._1 == name))
+
+        def findIndexed: Option[Either[String, (String, String)]] =
+          annotationParams.lift(pos).filter(_.isLeft)
+
+        (findNamed orElse findIndexed).map(_.fold(identity, _._2)).map { s =>
           pf.lift(s).getOrElse(sys.error(s"Invalid `$name` annotation value ($s)"))
         }
       }
@@ -340,7 +346,6 @@ object serviceImpl {
       case class RpcRequest(
           operation: Operation,
           compressionOption: Tree,
-          namespace: String,
           methodNameStyle: MethodNameStyle
       ) {
 

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCAnnotationParamTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCAnnotationParamTests.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2017-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package higherkindness.mu.rpc.protocol
+
+import higherkindness.mu.rpc.common._
+import org.scalatest._
+import org.scalatestplus.scalacheck.Checkers
+
+class RPCAnnotationParamTests extends RpcBaseTestSuite with BeforeAndAfterAll with Checkers {
+
+  case class Request(s: String)
+  case class Response(length: Int)
+
+  "The service annotation" should {
+
+    "compile when only the protocol is specified" in {
+
+      """
+        @service(Protobuf) trait ServiceDef1[F[_]] {
+          def proto(req: Request): F[Response]
+        }
+        @service(Avro) trait ServiceDef2[F[_]] {
+          def avro(req: Request): F[Response]
+        }
+        @service(AvroWithSchema) trait ServiceDef3[F[_]] {
+          def avroWithSchema(req: Request): F[Response]
+        }
+      """ should compile
+
+    }
+
+    "compile when the params are specified in order" in {
+
+      """
+        @service(Protobuf, Identity, Some("my.package"), Unchanged) trait ServiceDef1[F[_]] {
+          def proto(req: Request): F[Response]
+        }
+        @service(Avro, Gzip, Some("my.package"), Unchanged) trait ServiceDef2[F[_]] {
+          def avro(req: Request): F[Response]
+        }
+        @service(AvroWithSchema, Identity, Some("my.package"), Capitalize) trait ServiceDef3[F[_]] {
+          def avroWithSchema(req: Request): F[Response]
+        }
+      """ should compile
+
+    }
+
+    "compile when the params are specified with name" in {
+
+      """
+        @service(serializationType = Protobuf, compressionType = Identity, namespace = Some("my.package"), methodNameStyle = Unchanged) trait ServiceDef1[F[_]] {
+          def proto(req: Request): F[Response]
+        }
+        @service(serializationType = Avro, compressionType = Gzip, namespace = Some("my.package"), methodNameStyle = Unchanged) trait ServiceDef2[F[_]] {
+          def avro(req: Request): F[Response]
+        }
+        @service(serializationType = AvroWithSchema, compressionType = Identity, namespace = Some("my.package"), methodNameStyle = Capitalize) trait ServiceDef3[F[_]] {
+          def avroWithSchema(req: Request): F[Response]
+        }
+      """ should compile
+
+    }
+
+    "compile when the params are specified with name and in different order" in {
+
+      """
+        @service(compressionType = Identity, namespace = Some("my.package"), serializationType = Protobuf, methodNameStyle = Unchanged) trait ServiceDef1[F[_]] {
+          def proto(req: Request): F[Response]
+        }
+        @service(compressionType = Gzip, namespace = Some("my.package"), methodNameStyle = Unchanged, serializationType = Avro) trait ServiceDef2[F[_]] {
+          def avro(req: Request): F[Response]
+        }
+        @service(namespace = Some("my.package"), methodNameStyle = Capitalize, serializationType = AvroWithSchema, compressionType = Identity) trait ServiceDef3[F[_]] {
+          def avroWithSchema(req: Request): F[Response]
+        }
+      """ should compile
+
+    }
+
+    "compile when some params are specified in order and others with name" in {
+
+      """
+        @service(Protobuf, Identity, namespace = Some("my.package"), methodNameStyle = Unchanged) trait ServiceDef1[F[_]] {
+          def proto(req: Request): F[Response]
+        }
+        @service(Avro, Gzip, Some("my.package"), methodNameStyle = Unchanged) trait ServiceDef2[F[_]] {
+          def avro(req: Request): F[Response]
+        }
+        @service(serializationType = AvroWithSchema, Identity, Some("my.package"), methodNameStyle = Capitalize) trait ServiceDef3[F[_]] {
+          def avroWithSchema(req: Request): F[Response]
+        }
+      """ should compile
+
+    }
+  }
+}

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCMethodNameTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCMethodNameTests.scala
@@ -32,13 +32,13 @@ class RPCMethodNameTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
     case class Response(length: Int)
 
-    @service(Protobuf, Identity, None, Capitalize) trait ProtoRPCServiceDef[F[_]] {
-      def proto1(req: Request): F[Response]
+    @service(Protobuf, methodNameStyle = Capitalize) trait ProtoRPCServiceDef[F[_]] {
+      def proto(req: Request): F[Response]
     }
-    @service(Avro, Identity, None, Capitalize) trait AvroRPCServiceDef[F[_]] {
+    @service(Avro, methodNameStyle = Capitalize) trait AvroRPCServiceDef[F[_]] {
       def avro(req: Request): F[Response]
     }
-    @service(AvroWithSchema, Identity, None, Capitalize) trait AvroWithSchemaRPCServiceDef[F[_]] {
+    @service(AvroWithSchema, methodNameStyle = Capitalize) trait AvroWithSchemaRPCServiceDef[F[_]] {
       def avroWithSchema(req: Request): F[Response]
     }
 
@@ -47,7 +47,7 @@ class RPCMethodNameTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
         with AvroRPCServiceDef[F]
         with AvroWithSchemaRPCServiceDef[F] {
 
-      def proto1(bd: Request): F[Response]         = Response(bd.s.length).pure
+      def proto(bd: Request): F[Response]          = Response(bd.s.length).pure
       def avro(bd: Request): F[Response]           = Response(bd.s.length).pure
       def avroWithSchema(bd: Request): F[Response] = Response(bd.s.length).pure
     }
@@ -68,7 +68,7 @@ class RPCMethodNameTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
         ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](_)) { client =>
         check {
           forAll { s: String =>
-            client.proto1(Request(s)).map(_.length).unsafeRunSync() == s.length
+            client.proto(Request(s)).map(_.length).unsafeRunSync() == s.length
           }
         }
       }

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCNamespaceTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCNamespaceTests.scala
@@ -32,13 +32,14 @@ class RPCNamespaceTests extends RpcBaseTestSuite with BeforeAndAfterAll with Che
 
     case class Response(length: Int)
 
-    @service(Protobuf, Identity, Some("my.namespace")) trait ProtoRPCServiceDef[F[_]] {
+    @service(Protobuf, namespace = Some("my.namespace")) trait ProtoRPCServiceDef[F[_]] {
       def proto1(req: Request): F[Response]
     }
-    @service(Avro, Identity, Some("my.namespace")) trait AvroRPCServiceDef[F[_]] {
+    @service(Avro, namespace = Some("my.namespace")) trait AvroRPCServiceDef[F[_]] {
       def avro(req: Request): F[Response]
     }
-    @service(AvroWithSchema, Identity, Some("my.namespace")) trait AvroWithSchemaRPCServiceDef[F[_]] {
+    @service(AvroWithSchema, namespace = Some("my.namespace")) trait AvroWithSchemaRPCServiceDef[
+        F[_]] {
       def avroWithSchema(req: Request): F[Response]
     }
 


### PR DESCRIPTION
## What this does?
Allows specifying named params in the service annotation

## Checklist

- [ ] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.

