### PR TITLE
Fixes plugin release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
         - if grep -q "SNAPSHOT" version.sbt; then
             sbt idlgen-sbt/publish;
           else
-            sbt idlgen-sbt/release;
+            sbt ";project idlgen-sbt; release";
           fi
     - stage: deploy
       scala: 2.12.8


### PR DESCRIPTION
## What this does?
The command `sbt idlgen-sbt/publish;` fails with the following error:

```
[error] Expected ':'
[error] Not a valid key: release (similar: releaseVcs, releaseVcsSign, releaseProcess)
[error] idlgen-sbt/release
[error]                   ^
```

https://travis-ci.org/higherkindness/mu/jobs/529241748#L584-L587

## Checklist

- [ ] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.

