### PR TITLE
Use updated Skeuomorph version for non-primitive protobuf fields

### DIFF
--- a/modules/examples/seed/client/modules/process/src/main/scala/example/seed/client/process/AvroPeopleServiceClient.scala
+++ b/modules/examples/seed/client/modules/process/src/main/scala/example/seed/client/process/AvroPeopleServiceClient.scala
@@ -51,14 +51,12 @@ object AvroPeopleServiceClient {
 
     }
 
-  def createClient[F[_]: ContextShift: Logger](
-      hostname: String,
-      port: Int)(
+  def createClient[F[_]: ContextShift: Logger](hostname: String, port: Int)(
       implicit F: ConcurrentEffect[F]): fs2.Stream[F, AvroPeopleServiceClient[F]] = {
 
     val channel: F[ManagedChannel] =
       F.delay(InetAddress.getByName(hostname).getHostAddress).flatMap { ip =>
-        val channelFor    = ChannelForAddress(ip, port)
+        val channelFor = ChannelForAddress(ip, port)
         new ManagedChannelInterpreter[F](channelFor, List(UsePlaintext())).build
       }
 

--- a/modules/examples/seed/client/modules/process/src/main/scala/example/seed/client/process/ProtoPeopleServiceClient.scala
+++ b/modules/examples/seed/client/modules/process/src/main/scala/example/seed/client/process/ProtoPeopleServiceClient.scala
@@ -73,14 +73,12 @@ object ProtoPeopleServiceClient {
 
     }
 
-  def createClient[F[_]: ContextShift: Logger: Timer](
-      hostname: String,
-      port: Int)(
+  def createClient[F[_]: ContextShift: Logger: Timer](hostname: String, port: Int)(
       implicit F: ConcurrentEffect[F]): fs2.Stream[F, ProtoPeopleServiceClient[F]] = {
 
     val channel: F[ManagedChannel] =
       F.delay(InetAddress.getByName(hostname).getHostAddress).flatMap { ip =>
-        val channelFor    = ChannelForAddress(ip, port)
+        val channelFor = ChannelForAddress(ip, port)
         new ManagedChannelInterpreter[F](channelFor, List(UsePlaintext())).build
       }
 

--- a/modules/idlgen/core/src/test/scala/higherkindness/mu/rpc/idlgen/ProtoSrcGenTests.scala
+++ b/modules/idlgen/core/src/test/scala/higherkindness/mu/rpc/idlgen/ProtoSrcGenTests.scala
@@ -48,10 +48,10 @@ class ProtoSrcGenTests extends RpcBaseTestSuite {
       |
       |object book {
       |
-      |@message final case class Book(isbn: Long, title: String, author: List[Author], binding_type: BindingType)
+      |@message final case class Book(isbn: Long, title: String, author: List[Option[Author]], binding_type: Option[BindingType])
       |@message final case class GetBookRequest(isbn: Long)
-      |@message final case class GetBookViaAuthor(author: Author)
-      |@message final case class BookStore(name: String, books: Map[Long, String], genres: List[Genre], payment_method: Long :+: Int :+: String :+: Book :+: CNil)
+      |@message final case class GetBookViaAuthor(author: Option[Author])
+      |@message final case class BookStore(name: String, books: Map[Long, String], genres: List[Option[Genre]], payment_method: Cop[Long :: Int :: String :: Option[Book] :: TNil])
       |
       |sealed trait Genre
       |object Genre {
@@ -69,9 +69,9 @@ class ProtoSrcGenTests extends RpcBaseTestSuite {
       |
       |@service(Protobuf) trait BookService[F[_]] {
       |  def GetBook(req: GetBookRequest): F[Book]
-      |  def GetBooksViaAuthor(req: GetBookViaAuthor): Stream[F, Book]
-      |  def GetGreatestBook(req: Stream[F, GetBookRequest]): F[Book]
-      |  def GetBooks(req: Stream[F, GetBookRequest]): Stream[F, Book]
+      |  def GetBooksViaAuthor(req: GetBookViaAuthor): fs2.Stream[F, Book]
+      |  def GetGreatestBook(req: fs2.Stream[F, GetBookRequest]): F[Book]
+      |  def GetBooks(req: fs2.Stream[F, GetBookRequest]): fs2.Stream[F, Book]
       |}
       |
       |}""".stripMargin

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -52,7 +52,7 @@ object ProjectPlugin extends AutoPlugin {
       val scalacheckToolbox: String  = "0.2.5"
       val scalamockScalatest: String = "3.6.0"
       val scalatest: String          = "3.0.6"
-      val skeuomorph: String         = "0.0.8"
+      val skeuomorph: String         = "0.0.9.1"
       val slf4j: String              = "1.7.26"
       val dropwizard: String         = "4.0.5"
     }


### PR DESCRIPTION
## What this does?
 - Fixes https://github.com/higherkindness/mu/issues/612, having optional fields for non-primitive protobuf fields.
 - Added `fs2` prefix to the Stream type of a test, which was also included in this release
## Checklist

- [x] Reviewed the diff to look for typos, println and format errors.
- [x] Updated the docs accordingly.

