### PR TITLE
Fix compile errors with the generated source code

### DIFF
--- a/modules/idlgen/core/src/main/scala/higherkindness/mu/rpc/idlgen/proto/ProtoSrcGenerator.scala
+++ b/modules/idlgen/core/src/main/scala/higherkindness/mu/rpc/idlgen/proto/ProtoSrcGenerator.scala
@@ -51,7 +51,7 @@ object ProtoSrcGenerator extends SrcGenerator {
       case a      => a
     }).mkString("\n")
 
-  val copRegExp: Regex = """((Cop\[)(((\w+)(\s)?(\:\:)(\s)?)+)(TNil)(\]))""".r
+  val copRegExp: Regex = """((Cop\[)(((\w+)((\[)(\w+)(\]))?(\s)?(\:\:)(\s)?)+)(TNil)(\]))""".r
 
   val cleanCop: String => String =
     _.replace("Cop[", "").replace("::", ":+:").replace("TNil]", "CNil")
@@ -78,5 +78,5 @@ object ProtoSrcGenerator extends SrcGenerator {
     s"${p.pkg.replace('.', '/')}/${p.name}$ScalaFileExtension"
 
   def imports(pkg: String): String =
-    s"$pkg\nimport higherkindness.mu.rpc.protocol._\nimport fs2.Stream\nimport shapeless.{:+:, CNil}"
+    s"$pkg\nimport higherkindness.mu.rpc.protocol._\nimport shapeless.{:+:, CNil}"
 }

--- a/modules/idlgen/core/src/main/scala/higherkindness/mu/rpc/idlgen/proto/ProtoSrcGenerator.scala
+++ b/modules/idlgen/core/src/main/scala/higherkindness/mu/rpc/idlgen/proto/ProtoSrcGenerator.scala
@@ -78,5 +78,5 @@ object ProtoSrcGenerator extends SrcGenerator {
     s"${p.pkg.replace('.', '/')}/${p.name}$ScalaFileExtension"
 
   def imports(pkg: String): String =
-    s"$pkg\nimport higherkindness.mu.rpc.protocol._\nimport shapeless.{:+:, CNil}"
+    s"$pkg\nimport higherkindness.mu.rpc.protocol._\nimport fs2.Stream\nimport shapeless.{:+:, CNil}"
 }

--- a/modules/idlgen/core/src/test/scala/higherkindness/mu/rpc/idlgen/ProtoSrcGenTests.scala
+++ b/modules/idlgen/core/src/test/scala/higherkindness/mu/rpc/idlgen/ProtoSrcGenTests.scala
@@ -42,6 +42,7 @@ class ProtoSrcGenTests extends RpcBaseTestSuite {
     """package com.proto
       |
       |import higherkindness.mu.rpc.protocol._
+      |import fs2.Stream
       |import shapeless.{:+:, CNil}
       |import com.proto.author.Author
       |
@@ -68,9 +69,9 @@ class ProtoSrcGenTests extends RpcBaseTestSuite {
       |
       |@service(Protobuf) trait BookService[F[_]] {
       |  def GetBook(req: GetBookRequest): F[Book]
-      |  def GetBooksViaAuthor(req: GetBookViaAuthor): fs2.Stream[F, Book]
-      |  def GetGreatestBook(req: fs2.Stream[F, GetBookRequest]): F[Book]
-      |  def GetBooks(req: fs2.Stream[F, GetBookRequest]): fs2.Stream[F, Book]
+      |  def GetBooksViaAuthor(req: GetBookViaAuthor): Stream[F, Book]
+      |  def GetGreatestBook(req: Stream[F, GetBookRequest]): F[Book]
+      |  def GetBooks(req: Stream[F, GetBookRequest]): Stream[F, Book]
       |}
       |
       |}""".stripMargin

--- a/modules/idlgen/core/src/test/scala/higherkindness/mu/rpc/idlgen/ProtoSrcGenTests.scala
+++ b/modules/idlgen/core/src/test/scala/higherkindness/mu/rpc/idlgen/ProtoSrcGenTests.scala
@@ -50,7 +50,7 @@ class ProtoSrcGenTests extends RpcBaseTestSuite {
       |@message final case class Book(isbn: Long, title: String, author: List[Option[Author]], binding_type: Option[BindingType])
       |@message final case class GetBookRequest(isbn: Long)
       |@message final case class GetBookViaAuthor(author: Option[Author])
-      |@message final case class BookStore(name: String, books: Map[Long, String], genres: List[Option[Genre]], payment_method: Cop[Long :: Int :: String :: Option[Book] :: TNil])
+      |@message final case class BookStore(name: String, books: Map[Long, String], genres: List[Option[Genre]], payment_method: Long :+: Int :+: String :+: Option[Book] :+: CNil)
       |
       |sealed trait Genre
       |object Genre {

--- a/modules/idlgen/core/src/test/scala/higherkindness/mu/rpc/idlgen/ProtoSrcGenTests.scala
+++ b/modules/idlgen/core/src/test/scala/higherkindness/mu/rpc/idlgen/ProtoSrcGenTests.scala
@@ -42,7 +42,6 @@ class ProtoSrcGenTests extends RpcBaseTestSuite {
     """package com.proto
       |
       |import higherkindness.mu.rpc.protocol._
-      |import fs2.Stream
       |import shapeless.{:+:, CNil}
       |import com.proto.author.Author
       |

--- a/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/serviceImpl.scala
+++ b/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/serviceImpl.scala
@@ -52,10 +52,10 @@ object serviceImpl {
     }
     object TypeTypology {
       def apply(t: Tree): TypeTypology = t match {
-        case tq"Observable[..$tpts]"           => MonixObservableTpe(t, tpts.headOption)
-        case tq"fs2.Stream[$carrier, ..$tpts]" => Fs2StreamTpe(t, tpts.headOption)
-        case tq"Empty.type"                    => EmptyTpe(t)
-        case tq"$carrier[..$tpts]"             => UnaryTpe(t, tpts.headOption)
+        case tq"Observable[..$tpts]"       => MonixObservableTpe(t, tpts.headOption)
+        case tq"Stream[$carrier, ..$tpts]" => Fs2StreamTpe(t, tpts.headOption)
+        case tq"Empty.type"                => EmptyTpe(t)
+        case tq"$carrier[..$tpts]"         => UnaryTpe(t, tpts.headOption)
       }
     }
     case class EmptyTpe(tpe: Tree)                                extends TypeTypology(tpe, None)

--- a/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/serviceImpl.scala
+++ b/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/serviceImpl.scala
@@ -52,10 +52,10 @@ object serviceImpl {
     }
     object TypeTypology {
       def apply(t: Tree): TypeTypology = t match {
-        case tq"Observable[..$tpts]"       => MonixObservableTpe(t, tpts.headOption)
-        case tq"Stream[$carrier, ..$tpts]" => Fs2StreamTpe(t, tpts.headOption)
-        case tq"Empty.type"                => EmptyTpe(t)
-        case tq"$carrier[..$tpts]"         => UnaryTpe(t, tpts.headOption)
+        case tq"Observable[..$tpts]"           => MonixObservableTpe(t, tpts.headOption)
+        case tq"fs2.Stream[$carrier, ..$tpts]" => Fs2StreamTpe(t, tpts.headOption)
+        case tq"Empty.type"                    => EmptyTpe(t)
+        case tq"$carrier[..$tpts]"             => UnaryTpe(t, tpts.headOption)
       }
     }
     case class EmptyTpe(tpe: Tree)                                extends TypeTypology(tpe, None)

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -52,7 +52,7 @@ object ProjectPlugin extends AutoPlugin {
       val scalacheckToolbox: String  = "0.2.5"
       val scalamockScalatest: String = "3.6.0"
       val scalatest: String          = "3.0.6"
-      val skeuomorph: String         = "0.0.9.1"
+      val skeuomorph: String         = "0.0.10"
       val slf4j: String              = "1.7.26"
       val dropwizard: String         = "4.0.5"
     }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.18.2"
+version in ThisBuild := "0.18.3"


### PR DESCRIPTION
## What this does?
  - The "Cop" regex was not picking up the new Option[A] types
  - The "fs2" prefix on Stream was causing the macro to generate the wrong code

## Checklist

- [x] Reviewed the diff to look for typos, println and format errors.
- [x] Updated the docs accordingly.

