### PR TITLE
Allows generating idiomatic gRPC urls for avro

### DIFF
--- a/docs/src/main/tut/generate-sources-from-idl.md
+++ b/docs/src/main/tut/generate-sources-from-idl.md
@@ -74,13 +74,14 @@ Basic settings:
 
 Extra settings:
 
-* **`genOptions`**: additional options to add to the generated `@service` annotations, after the IDL type. Currently only supports `"Gzip"`.
 * **`srcGenJarNames`**: the list of jar names or sbt modules containing the IDL definitions that will be used at compilation time by `srcGen` to generate the Scala sources. By default, this sequence is empty.
 * **`idlGenBigDecimal`**: specifies how the `decimal` types will be generated. `ScalaBigDecimalGen` produces `scala.math.BigDecimal` and `ScalaBigDecimalTaggedGen` produces `scala.math.BigDecimal` but tagged with the 'precision' and 'scale'. i.e. `scala.math.BigDecimal @@ (Nat._8, Nat._2)`. By default `ScalaBigDecimalTaggedGen`.
 * **`idlGenMarshallerImports`**: additional imports to add on top to the generated service files. This property can be used for importing extra codecs for your services. By default:
   * `List(BigDecimalAvroMarshallers, JavaTimeDateAvroMarshallers)` if `srcGenSerializationType` is `Avro` or `AvroWithSchema` and `idlGenBigDecimal` is `ScalaBigDecimalGen`
   * `List(BigDecimalTaggedAvroMarshallers, JavaTimeDateAvroMarshallers)` if `srcGenSerializationType` is `Avro` or `AvroWithSchema` and `idlGenBigDecimal` is `ScalaBigDecimalTaggedGen`
   * `List(BigDecimalProtobufMarshallers, JavaTimeDateProtobufMarshallers)` if `srcGenSerializationType` is `Protobuf`.
+* **`idlGenCompressionType`**: Only for `avro`. Specifies the compression type that will be used by the IDL generated services. Set to `higherkindness.mu.rpc.idlgen.Model.GzipGen` for compressed communications with Gzip. `higherkindness.mu.rpc.idlgen.Model.NoCompressionGen` by default.
+* **`idlGenIdiomaticEndpoints`**: Only for `avro`. Flag indicating if idiomatic gRPC endpoints should be used. If `true`, the service operations will be prefixed by the namespace and the methods will be capitalized. `false` by default.  
 
 The `JodaDateTimeAvroMarshallers` and `JodaDateTimeProtobufMarshallers` are also available, but they need the dependency `mu-rpc-marshallers-jodatime`. You can also specify custom imports with the following:
   * `idlGenMarshallerImports := List(higherkindness.mu.rpc.idlgen.Model.CustomMarshallersImport("com.sample.marshallers._"))`

--- a/modules/idlgen/core/src/main/scala/higherkindness/mu/rpc/idlgen/Model.scala
+++ b/modules/idlgen/core/src/main/scala/higherkindness/mu/rpc/idlgen/Model.scala
@@ -19,6 +19,8 @@ package higherkindness.mu.rpc.idlgen
 import higherkindness.mu.rpc.idlgen.util.Toolbox
 import higherkindness.mu.rpc.internal.util.StringUtil._
 import higherkindness.mu.rpc.protocol._
+import shapeless.tag
+import shapeless.tag.@@
 
 object Model {
 
@@ -87,4 +89,17 @@ object Model {
   sealed trait BigDecimalTypeGen       extends Product with Serializable
   case object ScalaBigDecimalGen       extends BigDecimalTypeGen
   case object ScalaBigDecimalTaggedGen extends BigDecimalTypeGen
+
+  sealed abstract class CompressionTypeGen(val value: String) extends Product with Serializable
+  case object GzipGen                                         extends CompressionTypeGen("Gzip")
+  case object NoCompressionGen                                extends CompressionTypeGen("Identity")
+
+  trait UseIdiomaticEndpointsTag
+  type UseIdiomaticEndpoints = Boolean @@ UseIdiomaticEndpointsTag
+  object UseIdiomaticEndpoints {
+    val trueV = UseIdiomaticEndpoints(true)
+
+    def apply(v: Boolean): UseIdiomaticEndpoints =
+      tag[UseIdiomaticEndpointsTag][Boolean](v)
+  }
 }

--- a/modules/idlgen/core/src/main/scala/higherkindness/mu/rpc/idlgen/SrcGenApplication.scala
+++ b/modules/idlgen/core/src/main/scala/higherkindness/mu/rpc/idlgen/SrcGenApplication.scala
@@ -18,20 +18,27 @@ package higherkindness.mu.rpc.idlgen
 
 import higherkindness.mu.rpc.idlgen.Model.{
   BigDecimalTypeGen,
+  CompressionTypeGen,
   MarshallersImport,
-  ScalaBigDecimalTaggedGen
+  UseIdiomaticEndpoints
 }
 import higherkindness.mu.rpc.idlgen.avro.AvroSrcGenerator
 import higherkindness.mu.rpc.idlgen.proto.ProtoSrcGenerator
 
 object SrcGenApplication {
   def apply(
-      marshallersImports: List[MarshallersImport] = Nil,
-      bigDecimalTypeGen: BigDecimalTypeGen = ScalaBigDecimalTaggedGen): GeneratorApplication[
-    SrcGenerator] =
+      marshallersImports: List[MarshallersImport],
+      bigDecimalTypeGen: BigDecimalTypeGen,
+      compressionType: CompressionTypeGen,
+      useIdiomaticEndpoints: UseIdiomaticEndpoints
+  ): GeneratorApplication[SrcGenerator] =
     new GeneratorApplication(
       ProtoSrcGenerator,
-      AvroSrcGenerator(marshallersImports, bigDecimalTypeGen)) {
+      AvroSrcGenerator(
+        marshallersImports,
+        bigDecimalTypeGen,
+        compressionType,
+        useIdiomaticEndpoints)) {
       def main(args: Array[String]): Unit = {
         generateFrom(args)
         (): Unit

--- a/modules/idlgen/core/src/main/scala/higherkindness/mu/rpc/idlgen/package.scala
+++ b/modules/idlgen/core/src/main/scala/higherkindness/mu/rpc/idlgen/package.scala
@@ -16,8 +16,6 @@
 
 package higherkindness.mu.rpc
 
-import higherkindness.mu.rpc.idlgen.avro._
-import higherkindness.mu.rpc.idlgen.proto.ProtoIdlGenerator
 import higherkindness.mu.rpc.idlgen.util.Toolbox.u._
 import higherkindness.mu.rpc.idlgen.util.AstOptics.ast
 import higherkindness.mu.rpc.protocol.{Avro, AvroWithSchema, Protobuf, SerializationType}
@@ -28,14 +26,6 @@ package object idlgen {
   val EmptyType               = "Empty.type"
 
   val ScalaFileExtension = ".scala"
-
-  val idlGenerators: Map[String, IdlGenerator] = Seq(ProtoIdlGenerator, AvroIdlGenerator)
-    .map(g => g.idlType -> g)
-    .toMap
-
-  val srcGenerators: Map[String, SrcGenerator] = Seq(AvroSrcGenerator())
-    .map(g => g.idlType -> g)
-    .toMap
 
   val serializationTypes: Map[String, SerializationType] =
     Map("Protobuf" -> Protobuf, "Avro" -> Avro, "AvroWithSchema" -> AvroWithSchema)

--- a/modules/idlgen/core/src/test/scala/higherkindness/mu/rpc/idlgen/AvroScalaGeneratorArbitrary.scala
+++ b/modules/idlgen/core/src/test/scala/higherkindness/mu/rpc/idlgen/AvroScalaGeneratorArbitrary.scala
@@ -47,7 +47,7 @@ trait AvroScalaGeneratorArbitrary {
       if (options.isEmpty) {
         serializationType ::
           s"compressionType = ${compressionTypeGen.value}" ::
-          List(s"""namespace = Some("foo.bar")""", "methodNameStyle = Capitalize").filterNot(_ =>
+          List(s"""namespace = Some("foo.bar")""", "methodNameStyle = Capitalize").filter(_ =>
           useIdiomaticEndpoints)
       } else serializationType +: options.toSeq
 

--- a/modules/idlgen/core/src/test/scala/higherkindness/mu/rpc/idlgen/SrcGenTests.scala
+++ b/modules/idlgen/core/src/test/scala/higherkindness/mu/rpc/idlgen/SrcGenTests.scala
@@ -18,6 +18,7 @@ package higherkindness.mu.rpc.idlgen
 
 import higherkindness.mu.rpc.common.RpcBaseTestSuite
 import higherkindness.mu.rpc.idlgen.AvroScalaGeneratorArbitrary._
+import higherkindness.mu.rpc.idlgen.Model.ScalaBigDecimalTaggedGen
 import higherkindness.mu.rpc.idlgen.avro._
 import org.scalatestplus.scalacheck.Checkers
 import org.scalacheck.Prop.forAll
@@ -37,7 +38,11 @@ class SrcGenTests extends RpcBaseTestSuite with Checkers {
 
   private def test(scenario: Scenario): Boolean = {
     val output =
-      AvroSrcGenerator(scenario.marshallersImports)
+      AvroSrcGenerator(
+        scenario.marshallersImports,
+        ScalaBigDecimalTaggedGen,
+        scenario.compressionTypeGen,
+        scenario.useIdiomaticEndpoints)
         .generateFrom(
           resource(scenario.inputResourcePath).mkString,
           scenario.serializationType,

--- a/modules/idlgen/plugin/src/main/scala/higherkindness/mu/rpc/idlgen/IdlGenPlugin.scala
+++ b/modules/idlgen/plugin/src/main/scala/higherkindness/mu/rpc/idlgen/IdlGenPlugin.scala
@@ -73,6 +73,7 @@ object IdlGenPlugin extends AutoPlugin {
         "The Scala target directory, where the `srcGen` task will write the generated files " +
           "in subpackages based on the namespaces declared in the IDL files.")
 
+    @deprecated("Use the specific settings like `idlGenCompressionType` or `idlGenIdiomaticEndpoints`", "0.18.4")
     lazy val genOptions: SettingKey[Seq[String]] =
       settingKey[Seq[String]](
         "Options for the generator, such as additional @service annotation parameters in srcGen.")
@@ -86,6 +87,15 @@ object IdlGenPlugin extends AutoPlugin {
       settingKey[List[MarshallersImport]](
         "List of imports needed for creating the request/response marshallers. " +
           "By default, this include the instances for serializing `BigDecimal`, `java.time.LocalDate`, and `java.time.LocalDateTime`")
+
+    lazy val idlGenCompressionType: SettingKey[CompressionTypeGen] =
+      settingKey[CompressionTypeGen](
+        "Specifies the compression type. `NoCompressionGen` by default.")
+
+    lazy val idlGenIdiomaticEndpoints: SettingKey[Boolean] =
+      settingKey[Boolean](
+        "If `true`, the gRPC endpoints generated in the services generated from idls will contain the " +
+          "namespace as prefix and their method names will be capitalized. `false` by default.")
   }
 
   import higherkindness.mu.rpc.idlgen.IdlGenPlugin.autoImport._
@@ -113,7 +123,9 @@ object IdlGenPlugin extends AutoPlugin {
       else if (srcGenSerializationType.value == "Protobuf")
         List(BigDecimalProtobufMarshallers, JavaTimeDateProtobufMarshallers)
       else Nil
-    }
+    },
+    idlGenCompressionType := GzipGen,
+    idlGenIdiomaticEndpoints := false
   )
 
   lazy val taskSettings: Seq[Def.Setting[_]] = {
@@ -150,7 +162,12 @@ object IdlGenPlugin extends AutoPlugin {
           },
           Def.task {
             idlGenTask(
-              SrcGenApplication(idlGenMarshallerImports.value, idlGenBigDecimal.value),
+              SrcGenApplication(
+                idlGenMarshallerImports.value,
+                idlGenBigDecimal.value,
+                idlGenCompressionType.value,
+                UseIdiomaticEndpoints(idlGenIdiomaticEndpoints.value)
+              ),
               idlType.value,
               srcGenSerializationType.value,
               genOptions.value,
@@ -208,6 +225,7 @@ object IdlGenPlugin extends AutoPlugin {
               overwrite = true,
               preserveLastModified = true,
               preserveExecutable = true)
+            (): Unit
           } else if (classpathEntry.data.exists) {
             IO.unzip(classpathEntry.data, tmpDir, nameFilter)
             IO.copyDirectory(tmpDir, target)

--- a/modules/idlgen/plugin/src/main/scala/higherkindness/mu/rpc/idlgen/IdlGenPlugin.scala
+++ b/modules/idlgen/plugin/src/main/scala/higherkindness/mu/rpc/idlgen/IdlGenPlugin.scala
@@ -124,7 +124,7 @@ object IdlGenPlugin extends AutoPlugin {
         List(BigDecimalProtobufMarshallers, JavaTimeDateProtobufMarshallers)
       else Nil
     },
-    idlGenCompressionType := GzipGen,
+    idlGenCompressionType := NoCompressionGen,
     idlGenIdiomaticEndpoints := false
   )
 

--- a/modules/idlgen/plugin/src/sbt-test/sbt-mu-idlgen/gzipCompression/test
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-mu-idlgen/gzipCompression/test
@@ -13,3 +13,21 @@ $ exists src/main/resources/service.avdl
 > srcGen
 > compile
 $ exists target/scala-2.12/src_managed/main/io/higherkindness/service.scala
+$ delete target/scala-2.12/src_managed/main/io/higherkindness/service.scala
+
+$ exists src/main/resources/service.avdl
+> 'set idlType := "avro"'
+> 'set srcGenSerializationType := "AvroWithSchema"'
+> 'set idlGenCompressionType := higherkindness.mu.rpc.idlgen.Model.GzipGen'
+> srcGen
+> compile
+$ exists target/scala-2.12/src_managed/main/io/higherkindness/service.scala
+$ delete target/scala-2.12/src_managed/main/io/higherkindness/service.scala
+
+$ exists src/main/resources/service.avdl
+> 'set idlType := "avro"'
+> 'set srcGenSerializationType := "AvroWithSchema"'
+> 'set idlGenCompressionType := higherkindness.mu.rpc.idlgen.Model.NoCompressionGen'
+> srcGen
+> compile
+$ exists target/scala-2.12/src_managed/main/io/higherkindness/service.scala

--- a/modules/idlgen/plugin/src/sbt-test/sbt-mu-idlgen/idiomaticEndpoints/build.sbt
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-mu-idlgen/idiomaticEndpoints/build.sbt
@@ -1,0 +1,5 @@
+version := sys.props("version")
+
+libraryDependencies ++= Seq(
+  "io.higherkindness" %% "mu-rpc-server" % sys.props("version")
+)

--- a/modules/idlgen/plugin/src/sbt-test/sbt-mu-idlgen/idiomaticEndpoints/project/plugins.sbt
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-mu-idlgen/idiomaticEndpoints/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.higherkindness" %% "sbt-mu-idlgen" % sys.props("version"))

--- a/modules/idlgen/plugin/src/sbt-test/sbt-mu-idlgen/idiomaticEndpoints/src/main/resources/service.avdl
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-mu-idlgen/idiomaticEndpoints/src/main/resources/service.avdl
@@ -1,0 +1,16 @@
+@namespace("io.higherkindness")
+protocol service {
+
+  record Foo {
+    string bar;
+  }
+
+  record Person {
+    long id;
+    string name;
+    union { null, string } email;
+  }
+
+  io.higherkindness.Person hi(io.higherkindness.Foo request);
+
+}

--- a/modules/idlgen/plugin/src/sbt-test/sbt-mu-idlgen/idiomaticEndpoints/test
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-mu-idlgen/idiomaticEndpoints/test
@@ -1,0 +1,15 @@
+$ exists src/main/resources/service.avdl
+> 'set idlType := "avro"'
+> 'set srcGenSerializationType := "Avro"'
+> srcGen
+> compile
+$ exists target/scala-2.12/src_managed/main/io/higherkindness/service.scala
+$ delete target/scala-2.12/src_managed/main/io/higherkindness/service.scala
+
+$ exists src/main/resources/service.avdl
+> 'set idlType := "avro"'
+> 'set srcGenSerializationType := "AvroWithSchema"'
+> 'set idlGenIdiomaticEndpoints := true'
+> srcGen
+> compile
+$ exists target/scala-2.12/src_managed/main/io/higherkindness/service.scala


### PR DESCRIPTION
## What this does?

Relates to #599

Allows specifying the idiomatic endpoints through a setting key.

It also deprecates `genOptions` and adds a new setting for indicating the compression type.

## Checklist

- [ ] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.

