### PR TITLE
Fixes menu.yml

### DIFF
--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -12,7 +12,7 @@ options:
     url: annotations
 
   - title: Generate sources from IDL
-      url: generate-sources-from-idl
+    url: generate-sources-from-idl
 
   - title: IDL Generation
     url: idl-generation


### PR DESCRIPTION
## What this does?

The last release failed to publish the microsite:

```
[info] jekyll 3.2.1 | Error:  (/home/travis/build/higherkindness/mu/docs/target/scala-2.12/resource_managed/main/jekyll/_data/menu.yml): mapping values are not allowed in this context at line 15 column 10
[error] java.lang.RuntimeException: Could not run jekyll, error: 1
[error]     at scala.sys.package$.error(package.scala:26)
[error]     at com.typesafe.sbt.site.jekyll.JekyllPlugin$.generate(JekyllPlugin.scala:49)
[error]     at com.typesafe.sbt.site.jekyll.JekyllPlugin$.$anonfun$jekyllSettings$4(JekyllPlugin.scala:31)
[error]     at scala.Function1.$anonfun$compose$1(Function1.scala:44)
[error]     at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:40)
[error]     at sbt.std.Transform$$anon$4.work(System.scala:67)
[error]     at sbt.Execute.$anonfun$submit$2(Execute.scala:269)
[error]     at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
[error]     at sbt.Execute.work(Execute.scala:278)
[error]     at sbt.Execute.$anonfun$submit$1(Execute.scala:269)
[error]     at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[error]     at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error]     at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error]     at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error]     at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error]     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error]     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error]     at java.lang.Thread.run(Thread.java:748)
[error] (docs / Jekyll / mappings) Could not run jekyll, error: 1
```

It looks the indentation is the problem.

## Checklist

- [ ] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.

