### PR TITLE
Add import root to protobuf source generator

### DIFF
--- a/modules/idlgen/core/src/main/scala/higherkindness/mu/rpc/idlgen/SrcGenApplication.scala
+++ b/modules/idlgen/core/src/main/scala/higherkindness/mu/rpc/idlgen/SrcGenApplication.scala
@@ -16,6 +16,8 @@
 
 package higherkindness.mu.rpc.idlgen
 
+import java.io.File
+
 import higherkindness.mu.rpc.idlgen.Model.{
   BigDecimalTypeGen,
   CompressionTypeGen,
@@ -30,10 +32,11 @@ object SrcGenApplication {
       marshallersImports: List[MarshallersImport],
       bigDecimalTypeGen: BigDecimalTypeGen,
       compressionType: CompressionTypeGen,
-      useIdiomaticEndpoints: UseIdiomaticEndpoints
+      useIdiomaticEndpoints: UseIdiomaticEndpoints,
+      idlTargetDir: File
   ): GeneratorApplication[SrcGenerator] =
     new GeneratorApplication(
-      ProtoSrcGenerator.build(compressionType, useIdiomaticEndpoints),
+      ProtoSrcGenerator.build(compressionType, useIdiomaticEndpoints, idlTargetDir),
       AvroSrcGenerator(
         marshallersImports,
         bigDecimalTypeGen,

--- a/modules/idlgen/core/src/main/scala/higherkindness/mu/rpc/idlgen/proto/ProtoSrcGenerator.scala
+++ b/modules/idlgen/core/src/main/scala/higherkindness/mu/rpc/idlgen/proto/ProtoSrcGenerator.scala
@@ -39,7 +39,8 @@ object ProtoSrcGenerator {
 
   def build(
       compressionTypeGen: CompressionTypeGen,
-      useIdiomaticEndpoints: UseIdiomaticEndpoints): SrcGenerator = new SrcGenerator {
+      useIdiomaticEndpoints: UseIdiomaticEndpoints,
+      idlTargetDir: File): SrcGenerator = new SrcGenerator {
 
     val idlType: String = proto.IdlType
 
@@ -80,7 +81,7 @@ object ProtoSrcGenerator {
 
     private def getCode[F[_]: Sync](file: File): F[(String, Seq[String])] =
       parseProto[F, Mu[ProtobufF]]
-        .parse(ProtoSource(file.getName, file.getParent))
+        .parse(ProtoSource(file.getName, file.getParent, idlTargetDir.getCanonicalPath))
         .map(
           protocol =>
             getPath(protocol) -> Seq(

--- a/modules/idlgen/plugin/src/main/scala/higherkindness/mu/rpc/idlgen/IdlGenPlugin.scala
+++ b/modules/idlgen/plugin/src/main/scala/higherkindness/mu/rpc/idlgen/IdlGenPlugin.scala
@@ -73,7 +73,9 @@ object IdlGenPlugin extends AutoPlugin {
         "The Scala target directory, where the `srcGen` task will write the generated files " +
           "in subpackages based on the namespaces declared in the IDL files.")
 
-    @deprecated("Use the specific settings like `idlGenCompressionType` or `idlGenIdiomaticEndpoints`", "0.18.4")
+    @deprecated(
+      "Use the specific settings like `idlGenCompressionType` or `idlGenIdiomaticEndpoints`",
+      "0.18.4")
     lazy val genOptions: SettingKey[Seq[String]] =
       settingKey[Seq[String]](
         "Options for the generator, such as additional @service annotation parameters in srcGen.")
@@ -166,7 +168,8 @@ object IdlGenPlugin extends AutoPlugin {
                 idlGenMarshallerImports.value,
                 idlGenBigDecimal.value,
                 idlGenCompressionType.value,
-                UseIdiomaticEndpoints(idlGenIdiomaticEndpoints.value)
+                UseIdiomaticEndpoints(idlGenIdiomaticEndpoints.value),
+                srcGenIDLTargetDir.value
               ),
               idlType.value,
               srcGenSerializationType.value,


### PR DESCRIPTION
## What this does?
Adds a new value to skeuomorph's `ProtoSource` in order to provide a common root folder for protobuf imports (so they can be found even if they come from different folders and/or modules). This value is directly piped from `srcGenIDLTargetDir` into `ProtoSource`.

Check https://github.com/higherkindness/skeuomorph/pull/115 for skeuomorph's proposed change.

## Checklist

- [ ] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.
