### PR TITLE
Allow specifying custom serialization mechanism

### DIFF
--- a/docs/src/main/tut/annotations.md
+++ b/docs/src/main/tut/annotations.md
@@ -10,7 +10,7 @@ Below is a summary of all the current annotations that [Mu] provides:
 
 Annotation | Scope | Arguments | Description
 --- | --- | --- | ---
-@service | `Trait` | (`SerializationType`, `Compression`) | Tags the trait as an [RPC] service in order to derive server and client code (macro expansion). For the `SerializationType` parameter value, `Protobuf` and `Avro` are the current supported serialization methods. For the `Compression` parameter value, only `Gzip` is supported.
+@service | `Trait` | (`SerializationType`, `Compression`) | Tags the trait as an [RPC] service in order to derive server and client code (macro expansion). For the `SerializationType` parameter value, `Protobuf` and `Avro` are the current supported serialization methods. Also, you can specify `Custom` serialization method. In that case, you need to provide own implementation of `io.grpc.MethodDescriptor.Marshaller[A]` for your type A. For the `Compression` parameter value, only `Gzip` is supported.
 @message | `Case Class` | - | Tags the case class as an RPC message.
 @option | `Object` | `(name: String, value: Any)` | Defines the equivalent headers in `.proto` files.
 @outputPackage | `Object` | `(value: String)` | Defines the `package` declaration in `.proto` files, and the `namespace` tag in `.avpr` files.

--- a/modules/common/src/main/scala/higherkindness/mu/rpc/protocol/protocol.scala
+++ b/modules/common/src/main/scala/higherkindness/mu/rpc/protocol/protocol.scala
@@ -28,6 +28,7 @@ sealed trait SerializationType extends Product with Serializable
 case object Protobuf           extends SerializationType
 case object Avro               extends SerializationType
 case object AvroWithSchema     extends SerializationType
+case object Custom             extends SerializationType
 
 sealed abstract class CompressionType extends Product with Serializable
 case object Identity                  extends CompressionType

--- a/modules/idlgen/core/src/main/scala/higherkindness/mu/rpc/idlgen/ScalaParser.scala
+++ b/modules/idlgen/core/src/main/scala/higherkindness/mu/rpc/idlgen/ScalaParser.scala
@@ -93,6 +93,7 @@ object ScalaParser {
           case "Protobuf"       => Protobuf
           case "Avro"           => Avro
           case "AvroWithSchema" => AvroWithSchema
+          case "Custom"         => Custom
         })
   }
 }

--- a/modules/idlgen/core/src/main/scala/higherkindness/mu/rpc/idlgen/package.scala
+++ b/modules/idlgen/core/src/main/scala/higherkindness/mu/rpc/idlgen/package.scala
@@ -18,7 +18,7 @@ package higherkindness.mu.rpc
 
 import higherkindness.mu.rpc.idlgen.util.Toolbox.u._
 import higherkindness.mu.rpc.idlgen.util.AstOptics.ast
-import higherkindness.mu.rpc.protocol.{Avro, AvroWithSchema, Protobuf, SerializationType}
+import higherkindness.mu.rpc.protocol.{Avro, AvroWithSchema, Custom, Protobuf, SerializationType}
 
 package object idlgen {
 
@@ -28,7 +28,11 @@ package object idlgen {
   val ScalaFileExtension = ".scala"
 
   val serializationTypes: Map[String, SerializationType] =
-    Map("Protobuf" -> Protobuf, "Avro" -> Avro, "AvroWithSchema" -> AvroWithSchema)
+    Map(
+      "Protobuf"       -> Protobuf,
+      "Avro"           -> Avro,
+      "AvroWithSchema" -> AvroWithSchema,
+      "Custom"         -> Custom)
 
   object BaseType {
     def unapply(tpe: Tree): Option[String] = tpe match {

--- a/modules/idlgen/core/src/main/scala/higherkindness/mu/rpc/idlgen/util/AstOptics.scala
+++ b/modules/idlgen/core/src/main/scala/higherkindness/mu/rpc/idlgen/util/AstOptics.scala
@@ -18,7 +18,7 @@ package higherkindness.mu.rpc
 package idlgen
 package util
 
-import higherkindness.mu.rpc.protocol.{Avro, AvroWithSchema, Protobuf, SerializationType}
+import higherkindness.mu.rpc.protocol.{Avro, AvroWithSchema, Custom, Protobuf, SerializationType}
 import monocle._
 import monocle.function.all._
 
@@ -208,10 +208,12 @@ trait AstOptics {
     case Ident(TermName("Protobuf"))       => Protobuf
     case Ident(TermName("Avro"))           => Avro
     case Ident(TermName("AvroWithSchema")) => AvroWithSchema
+    case Ident(TermName("Custom"))         => Custom
   } {
     case Protobuf       => Ident(TermName("Protobuf"))
     case Avro           => Ident(TermName("Avro"))
     case AvroWithSchema => Ident(TermName("AvroWithSchema"))
+    case Custom         => Ident(TermName("Custom"))
   }
 
   val idlType: Traversal[Tree, SerializationType] =

--- a/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/serviceImpl.scala
+++ b/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/serviceImpl.scala
@@ -222,8 +222,9 @@ object serviceImpl {
           case "Protobuf"       => Protobuf
           case "Avro"           => Avro
           case "AvroWithSchema" => AvroWithSchema
+          case "Custom"         => Custom
         }.getOrElse(sys.error(
-          "@service annotation should have a SerializationType parameter [Protobuf|Avro|AvroWithSchema]"))
+          "@service annotation should have a SerializationType parameter [Protobuf|Avro|AvroWithSchema|Custom]"))
 
       val encodersImport = serializationType match {
         case Protobuf =>
@@ -232,6 +233,8 @@ object serviceImpl {
           List(q"import _root_.higherkindness.mu.rpc.internal.encoders.avro._")
         case AvroWithSchema =>
           List(q"import _root_.higherkindness.mu.rpc.internal.encoders.avrowithschema._")
+        case Custom =>
+          List.empty
       }
 
       val methodDescriptors: List[Tree] = rpcRequests.map(_.methodDescriptor)


### PR DESCRIPTION
## What this does?

We use own implementation of Protobuf protocol instead of using PbDirect.

If we specify `Protobuf` as the serialization method in our service definition, we can't use our implementation because `serviceImpl` macro automatically adds the import of PbDirect-specific implementation.

https://github.com/higherkindness/mu/blob/5a8a083e5177aa20e28163fab3a80f4ee1771918/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/serviceImpl.scala#L228-L235

This simple PR adds the possibility to specify the `Custom` serialization type in a service definition. Then we provide own implementation of `io.grpc.MethodDescriptor.Marshaller` for our types and it works!

## Checklist

- [x] Reviewed the diff to look for typos, println and format errors.
- [x] Updated the docs accordingly.

