### PR TITLE
Avoid adding unnecessary imports to generated source files

### DIFF
--- a/modules/idlgen/core/src/test/resources/proto/streaming_no_shapeless_no.proto
+++ b/modules/idlgen/core/src/test/resources/proto/streaming_no_shapeless_no.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package com.proto;
+
+message MyRequest {
+    string a = 1;
+}
+
+message MyResponse {
+    string a = 1;
+}
+
+service MyService {
+    rpc GetThing (MyRequest) returns (MyResponse) {}
+}

--- a/modules/idlgen/core/src/test/resources/proto/streaming_no_shapeless_yes.proto
+++ b/modules/idlgen/core/src/test/resources/proto/streaming_no_shapeless_yes.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package com.proto;
+
+message MyRequest {
+  oneof a {
+    int32 b = 1;
+    string c = 2;
+  }
+}
+
+message MyResponse {
+  string a = 1;
+}
+
+service MyService {
+  rpc GetThing (MyRequest) returns (MyResponse) {}
+}

--- a/modules/idlgen/core/src/test/resources/proto/streaming_yes_shapeless_no.proto
+++ b/modules/idlgen/core/src/test/resources/proto/streaming_yes_shapeless_no.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package com.proto;
+
+message MyRequest {
+    string a = 1;
+}
+
+message MyResponse {
+    string a = 1;
+}
+
+service MyService {
+    rpc GetThing (MyRequest) returns (stream MyResponse) {}
+}

--- a/modules/idlgen/core/src/test/resources/proto/streaming_yes_shapeless_yes.proto
+++ b/modules/idlgen/core/src/test/resources/proto/streaming_yes_shapeless_yes.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package com.proto;
+
+message MyRequest {
+  oneof a {
+    int32 b = 1;
+    string c = 2;
+  }
+}
+
+message MyResponse {
+  string a = 1;
+}
+
+service MyService {
+  rpc GetThing (MyRequest) returns (stream MyResponse) {}
+}

--- a/modules/idlgen/core/src/test/scala/higherkindness/mu/rpc/idlgen/AvroSrcGenTests.scala
+++ b/modules/idlgen/core/src/test/scala/higherkindness/mu/rpc/idlgen/AvroSrcGenTests.scala
@@ -23,7 +23,7 @@ import higherkindness.mu.rpc.idlgen.avro._
 import org.scalatestplus.scalacheck.Checkers
 import org.scalacheck.Prop.forAll
 
-class SrcGenTests extends RpcBaseTestSuite with Checkers {
+class AvroSrcGenTests extends RpcBaseTestSuite with Checkers {
 
   "Avro Scala Generator" should {
 

--- a/modules/idlgen/core/src/test/scala/higherkindness/mu/rpc/idlgen/ProtoSrcGenTests.scala
+++ b/modules/idlgen/core/src/test/scala/higherkindness/mu/rpc/idlgen/ProtoSrcGenTests.scala
@@ -33,14 +33,14 @@ class ProtoSrcGenTests extends RpcBaseTestSuite with OptionValues {
 
     "generate correct Scala classes" in {
 
-      val result: Option[(String, Seq[String])] =
+      val result: Option[(String, String)] =
         ProtoSrcGenerator
           .build(NoCompressionGen, UseIdiomaticEndpoints(false), new java.io.File("."))
           .generateFrom(files = Set(protoFile("book")), serializationType = "", options = "")
-          .map(t => (t._2, t._3.map(_.clean)))
+          .map(t => (t._2, t._3.mkString("\n").clean))
           .headOption
 
-      result shouldBe Some(("com/proto/book.scala", Seq(bookExpectation.clean)))
+      result shouldBe Some(("com/proto/book.scala", bookExpectation.clean))
     }
 
     case class ImportsTestCase(
@@ -65,7 +65,7 @@ class ProtoSrcGenTests extends RpcBaseTestSuite with OptionValues {
               files = Set(protoFile(test.protoFilename)),
               serializationType = "",
               options = "")
-            .flatMap(t => t._3)
+            .map(_._3.mkString("\n"))
             .headOption
 
         assert(result.value.contains("import fs2.") == test.shouldIncludeFS2Import)


### PR DESCRIPTION
When generating Scala from protobuf files, only add imports for things that are actually referenced in that file.

Also refactor `ProtoSrcGenerator` for consistency with the other generators. It now returns a list of the lines in the generated file instead of a singleton list containing the whole file contents.

TODO in a later PR: pass skeuomorph some kind of flag to tell it whether to use fs2 `Stream` or Monix `Observable` when generating service code.
## What this does?

Fixes #637 

## Checklist

- [ ] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.