### PR TITLE
Bumps avrohugger to 1.0.0-RC22

### DIFF
--- a/modules/idlgen/core/src/main/scala/higherkindness/mu/rpc/idlgen/avro/AvroSrcGenerator.scala
+++ b/modules/idlgen/core/src/main/scala/higherkindness/mu/rpc/idlgen/avro/AvroSrcGenerator.scala
@@ -39,8 +39,8 @@ case class AvroSrcGenerator(
   private[this] val logger = getLogger
 
   private val avroBigDecimal: AvroScalaDecimalType = bigDecimalTypeGen match {
-    case ScalaBigDecimalGen       => ScalaBigDecimal
-    case ScalaBigDecimalTaggedGen => ScalaBigDecimalWithPrecision
+    case ScalaBigDecimalGen       => ScalaBigDecimal(None)
+    case ScalaBigDecimalTaggedGen => ScalaBigDecimalWithPrecision(None)
   }
   private val avroScalaCustomTypes = Standard.defaultTypes.copy(decimal = avroBigDecimal)
   private val mainGenerator        = Generator(Standard, avroScalaCustomTypes = Some(avroScalaCustomTypes))

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -26,7 +26,7 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val V = new {
       val avro4s: String             = "1.8.4"
-      val avrohugger: String         = "1.0.0-RC19"
+      val avrohugger: String         = "1.0.0-RC22"
       val betterMonadicFor: String   = "0.3.1"
       val catsEffect: String         = "2.0.0"
       val circe: String              = "0.12.3"


### PR DESCRIPTION
## What this does?

Bumps avrohugger to 1.0.0-RC22

See https://github.com/julianpeeters/avrohugger/commit/f58bbfb7c2534586d0d781782a9fa96bc3ca3d0c

## Checklist

- [ ] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.

